### PR TITLE
MPI speedup of kinetic integration

### DIFF
--- a/install/DEFAULTS.inc
+++ b/install/DEFAULTS.inc
@@ -97,7 +97,7 @@
 #   ------------------------------------------------------------
 #
 #   Now compile using
-#    $ make FFLAGS="-qopenmp" 2>&1 | tee make.log
+#    $ make 2>&1 | tee make.log
 #
 # On iris.gat.com
 #   Developers should use the ifort compiler and associated netcdf module
@@ -128,7 +128,7 @@
 #   ------------------------------------------------------------
 #
 #   Now compile using
-#    $ make FFLAGS="-qopenmp" 2>&1 | tee make.log
+#    $ make 2>&1 | tee make.log
 #
 # On toki0*.aug.ipp.mpg.de
 #   Developers should use the ifort compiler as well as the associated impi and netcdf modules
@@ -189,6 +189,8 @@
 #     $ make FFLAGS="-qopenmp -qopt-report -g -O0 -check all"  # for debugging
 #     $ make FFLAGS="-qopenmp -O3"     # for optimized version
 #     $ make FFLAGS="-qopenmp  -xHost -O3 -qopt-zmm-usage=high -ipo"  # for old STRIDE options
+# If using a compiler other than intel, set OMPFLAG to whatever the equivalent of
+# -qopenmp is for your compiler.
 #
 # If your platform is not properly included in this make file
 # contact nlogan@pppl.gov with your operating system, compiler, and


### PR DESCRIPTION
This is a direct continuation of #82. 
I attempted to get that branch into develop without closing the PR thread, but git was too smart for me. Oh well.

At the opening of this new PR, the branch successfully improved the makefiles and enabled compiling dcon with or without openmp. The same treatment, using .F file extensions instead of .f, should probably be extended to STRIDE at some point. But this should not take priority over our main DCON & GPEC development. For convenience, I've  directly copied the top level outline from #82 below.

First, an overview information/computation flowchart:
![image](https://user-images.githubusercontent.com/6198372/51283987-c90b5100-199e-11e9-8ff9-b8a3fa75d7d8.png)

The important points are,
* A DCON run can take a long time if calculating the kinetic terms
  + This part is partly parallelized, but still loops serially over 100-500 radial points, filling in a MxM (M~100) complex matrix a each psi before forming it all into a spline in psi.
  + **Better speed and/or restart capability would be good in this fourfit_kinetic_matrix subroutine**
* Otherwise, DCON is fast and we don't really need restarts.
* GPEC and DCON are separate for historical reasons and need to stay that way. However, **users have expressed a desire for gpec to (optionally) call DCON as a subroutine**, eliminating the need for the slow and disk-space-intensive binary file interface.
* GPEC goes through some fast initial setup (reads euler.bin), and then basically runs a series of subroutines to output various quantities according to what flags the user set. **These are mostly independent, and could be done in parallel. Many of them also contain big loops through (independent) flux surfaces, which could be done in parallel.** But all use common global splines/variables and various subroutines that evaluate them (their "current" value is the value at the last requested psi, so evaluations cannot be mixed up!)... Is there an easy way to send "snapshots" of these to independent parallel calculations so they do not mess each other up?
* I think restarts of GPEC can be easy: just record which subroutines have been completed, and do not repeat them if restarting.

To prioritize:
1. Make fourfit_kinetic_matrix parallel over psi steps in `fourfit.f`
2. Parallelize GPEC subroutines in `gpec.f` (should be easy)
3. Enable single exe GPEC, with an all in-memory DCON interface
4. Parallelize slow GPEC subroutines that loop over many independent psi in `gpout.f`
