### PR TITLE
Fix compilation issues on newer versions of MacOS with GCC

### DIFF
--- a/install/DEFAULTS.inc
+++ b/install/DEFAULTS.inc
@@ -312,7 +312,7 @@ else
     FCDIR = .
     FCLIBS =
     FCINC = .
-    NETCDF_EXTRA_LIBS =
+#    NETCDF_EXTRA_LIBS =
 endif
 
 # SuperLU options
@@ -327,3 +327,10 @@ endif
 #ifneq some_magic_test_if_necessary_libs_are_in_path
 #	SLU_COMMAND =
 #endif
+
+# XDRAW options
+#----------------
+ifdef X11_HOME
+    X11_INC_DIR = -I$(X11_HOME)/include
+    X11_LIB_DIR = -L$(X11_HOME)/lib
+endif

--- a/superlu/remakeSuperLU.sh
+++ b/superlu/remakeSuperLU.sh
@@ -7,8 +7,12 @@
 rm *~
 rm -rf SuperLU_5.2.1
 tar -zxvf superlu_5.2.1.tar.gz
-cp make.inc SuperLU_5.2.1/make.inc
-sed -i 's@CURDIR@'"$PWD"'@' SuperLU_5.2.1/make.inc
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed 's@CURDIR@'"$PWD"'@' make.inc  > SuperLU_5.2.1/make.inc
+else
+  cp make.inc SuperLU_5.2.1/make.inc
+  sed -i 's@CURDIR@'"$PWD"'@' SuperLU_5.2.1/make.inc
+fi
 cp Makefile SuperLU_5.2.1/Makefile
 #Note: libblas.a NEEDN'T BE COPIED BY cp HERE,
 #      (LIKE THE 'make' FILES ABOVE ARE)

--- a/xdraw/binread.c
+++ b/xdraw/binread.c
@@ -26,7 +26,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#if !defined(__MACH__)
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <math.h>
 #include <ctype.h>

--- a/xdraw/makefile
+++ b/xdraw/makefile
@@ -1,7 +1,8 @@
 # This is the makefile for XDRAW on Linux computers.
+include ../install/DEFAULTS.inc
 
-CFLAGS = -DUNIX -O2
-CC = cc $(CFLAGS)
+CFLAGS = -DUNIX -O2 $(X11_INC_DIR)
+CC += $(CFLAGS)
 
 .c.o:
 	$(CC) -c $*.c
@@ -9,7 +10,8 @@ CC = cc $(CFLAGS)
 # Linux and OSX standards
 LIBDIR= \
 	-L/usr/X11R6/lib64 \
-	-L/opt/local/include
+	-L/opt/local/include \
+	$(X11_LIB_DIR)
 
 LIBS = \
 	$(LIBDIR) \

--- a/xdraw/spline.c
+++ b/xdraw/spline.c
@@ -6,7 +6,9 @@
 **	fits functions to cubic splines.
 ***********************************************************************/
 #include <stdio.h>
+#if !defined(__MACH__)
 #include <malloc.h>
+#endif
 #include "gendefs.h"
 #include "spline.h"
 

--- a/xdraw/spline1.c
+++ b/xdraw/spline1.c
@@ -18,11 +18,13 @@
 **	intermediate points, if so call spleval for those points.
 ***********************************************************************/
 #include <stdio.h>
+#if !defined(__MACH__)
 #include <malloc.h>
+#endif
 
 
 #define Float double
-#define ind(i,j) nd*(j-1)+(i+1) 
+#define ind(i,j) nd*(j-1)+(i+1)
 
 /* #define ind(i,j) n*(i+1)+(j-1)*/
 

--- a/xdraw/xcontour.c
+++ b/xdraw/xcontour.c
@@ -10,7 +10,9 @@
 ******************************************************************************/
 #include <stdio.h>
 #include <stdlib.h>
+#if !defined(__MACH__)
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <math.h>
 #include <ctype.h>

--- a/xdraw/xdraw.c
+++ b/xdraw/xdraw.c
@@ -69,7 +69,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#if !defined(__MACH__)
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <math.h>
 #include <fcntl.h>

--- a/xdraw/xedit.c
+++ b/xdraw/xedit.c
@@ -9,7 +9,9 @@
 ******************************************************************************/
 #include <stdio.h>
 #include <stdlib.h>
+#if !defined(__MACH__)
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <math.h>
 #include <ctype.h>

--- a/xdraw/xtools.c
+++ b/xdraw/xtools.c
@@ -10,7 +10,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#if !defined(__MACH__)
 #include <malloc.h>
+#endif
 #include <string.h>
 #include <fcntl.h>
 #include <math.h>


### PR DESCRIPTION
- Fix header issues in xdraw related to "malloc" on MacOS
- Add support for specifying a home directory for X11 (ie. Xorg)
- Fix errors in SuperLU build script on MacOS due to system "sed" version
- Fix NETCDF library error with non-Intel compilers