### PR TITLE
RMATCH - BUG FIX / ENHANCEMENT

### DIFF
--- a/rmatch/inps.f
+++ b/rmatch/inps.f
@@ -521,7 +521,7 @@ c     compute y and its derivatives with rvec.
 c-----------------------------------------------------------------------
       xfac=1/x**2
       rvec=-(/rt%r(1),rt%r(1),rt%r(2),rt%r(2)/)/2
-      cc=RESHAPE(ymat,(/4,kmax/))
+      cc=RESHAPE(ymat,(/4,kmax+1/))
       IF(PRESENT(dua))THEN
          CALL inps_horner(xfac,cc,yy,dyy,rvec)
          dy=-RESHAPE(dyy,(/2,2/))*2*xfac/x

--- a/rmatch/match.f
+++ b/rmatch/match.f
@@ -25,7 +25,9 @@ c     15. match_dealloc_sol.
 c     16. match_output_solution.
 c     17. match_auto_connect.
 c     18. match_eqscan.
-c     19. match_main.
+c     19. match_init_scan
+c     20. real_order
+c     21. match_main.
 c-----------------------------------------------------------------------
 c     subprogram 0. match_mod.
 c     module declarations.
@@ -85,6 +87,7 @@ c-----------------------------------------------------------------------
       
       LOGICAL :: scan_flag=.FALSE.,sol_flag=.FALSE.,qscan_flag=.FALSE.,
      $     matrix_diagnose=.FALSE.,eqscan_flag=.FALSE.
+      LOGICAL :: init_scan_flag=.FALSE.
       LOGICAL :: qscan_out=.TRUE.,deltar_flag=.FALSE.,deflate=.FALSE.,
      $           deltac_flag=.FALSE.,deltaj_flag=.FALSE.,
      $           match_flag=.FALSE.
@@ -133,7 +136,7 @@ c-----------------------------------------------------------------------
      $                         deltar_flag,deltac_flag,deltaj_flag,
      $                         deflate,nroot,match_flag,ising_output,
      $                         match_sol,matrix_diagnose,fulldomain,
-     $                         coil,itermax,relax_fac,
+     $                         coil,itermax,relax_fac,init_scan_flag,
      $                         scan_e0,scan_e1,eqscan_flag,scan_estep
       NAMELIST/rmatch_output/ bin_rpecsol,out_rpecsol
       NAMELIST/nyquist_input/nyquist
@@ -169,6 +172,10 @@ c-----------------------------------------------------------------------
       ALLOCATE (deltaf(totmsing,2,2))
       ALLOCATE (taur_save(totmsing))
       ALLOCATE (zi_in(msing),zo_out(msing),q_in(msing))
+      IF (totmsing.EQ.0) THEN
+         WRITE(*,*)"No singular surfaces."
+         stop
+      ENDIF
       IF (totmsing.LT.msing) THEN
          WRITE(*,*)"msing is larger than totmsing."
          msing=totmsing
@@ -249,6 +256,10 @@ c     scan over resistivity.
 c-----------------------------------------------------------------------
       IF (scan_flag) CALL match_eta_scan
 c-----------------------------------------------------------------------
+c     Test multiple initialization values and sort by growth rate
+c-----------------------------------------------------------------------
+      IF (init_scan_flag) CALL match_init_scan
+c-----------------------------------------------------------------------
 c     construct the global solution in both outer and inner regions.
 c-----------------------------------------------------------------------
       IF (match_flag) THEN
@@ -325,6 +336,7 @@ c-----------------------------------------------------------------------
       COMPLEX(r8), DIMENSION(4*msing) :: cof
       COMPLEX(r8), DIMENSION(4*msing,4*msing) :: mat
       COMPLEX(r8), DIMENSION(4*msing-1,4*msing-1) :: cmat
+      REAL(r8) :: nan
 c-----------------------------------------------------------------------
 c     format statements.
 c-----------------------------------------------------------------------
@@ -333,6 +345,11 @@ c-----------------------------------------------------------------------
 30    FORMAT(1x,"cof_out(",i2,") CL=",1p,2e11.3,"  CR=",1p,2e11.3)
 40    FORMAT(1x,"cof_in(",i2,")  d+=",1p,2e11.3,"  d-=",1p,2e11.3)
       itmax=itermax
+c-----------------------------------------------------------------------
+c     Setup NaN value
+c-----------------------------------------------------------------------
+      nan=0
+      nan=0/nan
 c-----------------------------------------------------------------------
 c     find initial guess.
 c-----------------------------------------------------------------------
@@ -345,19 +362,30 @@ c-----------------------------------------------------------------------
       DO
          it=it+1
          err=ABS(dz/z)
-         IF (it==1) THEN
-            WRITE (out_unit,10)
+         IF(.not.(scan_flag .or. qscan_flag .or. init_scan_flag)) then
+c           These write statements are too verbose for scans
+            IF (it==1) THEN
+               WRITE (out_unit,10)
+               WRITE(out_unit,*)
+               WRITE(out_unit,*)            
+            ENDIF
+            WRITE(out_unit,20)it,err,REAL(z),AIMAG(z),REAL(f),AIMAG(f)
             WRITE(out_unit,*)
-            WRITE(out_unit,*)            
          ENDIF
-         WRITE(out_unit,20)it,err,REAL(z),AIMAG(z),REAL(f),AIMAG(f)
-         WRITE(out_unit,*)
 
+         IF( ISNAN(REAL(f)) ) THEN
+            WRITE(*,*) "Solution is NaN. it=", it
+            WRITE(out_unit,*) "Solution is NaN. it=", it
+            it=-1
+            z=COMPLEX( nan,nan ) !NaN
+            EXIT
+         ENDIF
          IF(err < tol) EXIT
          IF(it > itmax) THEN
             it=-1
             WRITE(*,*) "Solution is not well converged."
             WRITE(out_unit,*) "Solution is not well converged."
+            z=COMPLEX( nan,nan ) !NaN
             EXIT
          ENDIF
          z_old=z
@@ -1901,10 +1929,140 @@ c     terminate.
 c-----------------------------------------------------------------------
       CALL program_stop("Normal termination for q scan.")
       END SUBROUTINE match_eqscan
+c-----------------------------------------------------------------------
+c     subprogram 19. match_init_scan.
+c     scan initguess and sort results by real component of eigenvalue
+c-----------------------------------------------------------------------
+c-----------------------------------------------------------------------
+c     declarations.
+c-----------------------------------------------------------------------            
+      SUBROUTINE match_init_scan
+      INTEGER :: istep,ising,iter,num_vals
+      REAL(r8) :: step,eta_scan,log_scan_x0,err
+      COMPLEX(r8) :: eigval0,eigval,detval
+      COMPLEX(r8), dimension(scan_nstep+1) :: eigvals, detvals
+      INTEGER, dimension(scan_nstep+1) :: order
+      COMPLEX(r8), DIMENSION(4*msing,4*msing) :: mat
+c-----------------------------------------------------------------------
+c     format output.
+c-----------------------------------------------------------------------                  
+10    FORMAT(/9x,"#re_gr",10x,"im_gr",2x,"iter",3x,"ising",
+     $       13x,"zi",13x,"zo",4x,"zi*SQRT(10)",10x,"zo/10",
+     $       7x,"re(q_in)",7x,"im(q_in)"/)
+20    FORMAT(1p,2e15.5,i6,i8,8e15.5)
+c-----------------------------------------------------------------------
+c     scan constant eta parameter.
+c-----------------------------------------------------------------------                  
+      log_scan_x0=log10(scan_x0)
+      step=(log10(scan_x1)-log_scan_x0)/scan_nstep
+      CALL bin_open(bin_unit,"scanres.bin","UNKNOWN","REWIND","none")
+      CALL ascii_open(debug_unit,"scanres.out","UNKNOWN")
+      WRITE (debug_unit,10)
+      !Scan real space for eigenvalues
+      num_vals=0
+      DO istep=0,scan_nstep
+         eigval=COMPLEX( 10**(log_scan_x0+istep*step), AIMAG(initguess))
+         eigval0=eigval
+         CALL match_newton(match_delta,eigval,err,iter)
+         detval=match_delta(eigval,mat)
+         IF( .not. ISNAN(REAL(eigval)) ) THEN
+            num_vals=num_vals+1
+            eigvals(num_vals)=eigval
+            detvals(num_vals)=detval
+         ENDIF
+         WRITE(out_unit,61) eigval0, eigval, detval
+         WRITE(*,61) eigval0, eigval, detval
+ 61      FORMAT(" init=(",1P,e11.3,e11.3," ) eigval=(",e11.3,e11.3,
+     $        " ) detval=(",e11.3,e11.3," )")
+      ENDDO
+
+      order = real_order(num_vals,eigvals)
+
+      !Print results
+      eigval0 = 0.0
+      iter=0
+      DO istep=1,num_vals
+
+         eigval=eigvals(order(istep))
+         detval=detvals(order(istep))
+         IF( abs(eigval-eigval0)/abs(eigval)>1e-3 ) THEN
+            iter = iter+1
+
+            ising=ising_output
+            WRITE(bin_unit)REAL(eta_scan,4),REAL(log10(eta_scan),4),
+     $         REAL(eigval,4),REAL(AIMAG(eigval),4),
+     $         floored_log(eigval),
+     $         REAL(zi_in(ising),4),REAL(zo_out(ising),4),
+     $         REAL(zi_in(ising)*SQRT(10.0),4),REAL(zo_out(ising)/10,4),
+     $         REAL(q_in(ising),4),REAL(AIMAG(q_in(ising)),4),
+     $         floored_log(q_in(ising)),REAL(iter,4)
+            WRITE(debug_unit,20)
+     $         REAL(eigval),IMAG(eigval),iter,ising,zi_in(ising),
+     $         zo_out(ising),zi_in(ising)*SQRT(10.0),zo_out(ising)/10,
+     $         REAL(q_in(ising)),IMAG(q_in(ising))
+            
+            WRITE(out_unit,62) iter, REAL(eigval), AIMAG(eigval), 
+     $           REAL(detval), AIMAG(detval)
+            WRITE(*,62) iter, REAL(eigval), AIMAG(eigval),
+     $           REAL(detval), AIMAG(detval)
+ 62         FORMAT("Branch ",i2," eigval=(",1P,e14.6,1x,e14.6,
+     $           " ) detval=("e14.6,1x,e14.6," )")
+
+            eigval0=eigval
+
+         ENDIF
       
+      ENDDO
+
+      WRITE(bin_unit)
+      CALL ascii_close(debug_unit)
+      CALL bin_close(bin_unit)
+c-----------------------------------------------------------------------
+c     terminate.
+c-----------------------------------------------------------------------
+      CALL program_stop("Normal termination for init scan.")
+      END SUBROUTINE match_init_scan
+c-----------------------------------------------------------------------
+c     function 20. real_order
+c     return an array of 'n' indices for complex array 'y' sorted
+c     in descending order by the real components of the elements.
+c-----------------------------------------------------------------------
+c-----------------------------------------------------------------------
+c     declarations.
+c-----------------------------------------------------------------------   
+      FUNCTION real_order(n,y)
+      INTEGER :: n
+      COMPLEX(r8),DIMENSION(n) :: y
+      INTEGER,DIMENSION(n) :: real_order, mask
+      REAL(r8) :: maxval
+      INTEGER :: i,j
+
+      mask=0
+c-----------------------------------------------------------------------
+c     Cycle over outputs
+c-----------------------------------------------------------------------
+      DO i=1,n
+c-----------------------------------------------------------------------
+c        Cycle over inputs
+c-----------------------------------------------------------------------
+         maxval=-9e37
+         DO j=1,n
+            if( mask(j)==0 .and. REAL(y(j))>maxval ) then
+               maxval=REAL(y(j))
+               real_order(i)=j
+            endif
+         ENDDO
+         mask(real_order(i))=1
+         
+      ENDDO
+c-----------------------------------------------------------------------
+c     terminate.
+c-----------------------------------------------------------------------
+      END FUNCTION
+
       END MODULE match_mod
 c-----------------------------------------------------------------------
-c     subprogram 19. match_main.
+c     subprogram 21. match_main.
 c     trivial main program.
 c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------


### PR DESCRIPTION
Fixed off-by-one reshape bug in inps.f:524, columns should be kmax+1.
Remerged match_init_scan that was present in version 1.3.8.

This modification include the production code used to generate the data for the Dylan Brennan / General Fusion papers.
https://iopscience.iop.org/article/10.1088/1741-4326/ab74a2
https://iopscience.iop.org/article/10.1088/1741-4326/abe68c