### PR TITLE
DCON - BUG FIX - Forces euler.bin outputs at critical steps

### DIFF
--- a/dcon/ode.f
+++ b/dcon/ode.f
@@ -60,6 +60,7 @@ c-----------------------------------------------------------------------
       SUBROUTINE ode_run
 
       CHARACTER(64) :: message
+      LOGICAL :: force_output, test, first
 c-----------------------------------------------------------------------
 c     initialize.
 c-----------------------------------------------------------------------
@@ -79,12 +80,19 @@ c-----------------------------------------------------------------------
 c     integrate.
 c-----------------------------------------------------------------------
       DO
+         first = .TRUE.
          DO
             IF(istep > 0)CALL ode_unorm(.FALSE.)
-            CALL ode_output_step(unorm)
+            ! always record the first and last point in an inter-rational region
+            ! these are important for resonant quantities
+            ! recording the last point is cirtical for matching the nominal edge
+            test = ode_test()
+            force_output = first .OR. test
+            CALL ode_output_step(unorm, op_force=force_output)
             CALL ode_record_edge
-            IF(ode_test())EXIT
+            IF(test)EXIT
             CALL ode_step
+            first = .FALSE.
          ENDDO
 c-----------------------------------------------------------------------
 c     re-initialize.

--- a/dcon/ode_output.f
+++ b/dcon/ode_output.f
@@ -167,9 +167,14 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
 c     declarations.
 c-----------------------------------------------------------------------
-      SUBROUTINE ode_output_step(unorm)
+      SUBROUTINE ode_output_step(unorm, op_force)
 
       REAL(r8), DIMENSION(:), INTENT(IN) :: unorm
+      LOGICAL, OPTIONAL :: op_force
+      LOGICAL :: force
+      ! set optional parameters
+      force = .FALSE.
+      IF(PRESENT(op_force)) force = op_force
 c-----------------------------------------------------------------------
 c     compute and print critical data for each time step.
 c-----------------------------------------------------------------------
@@ -178,7 +183,7 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
 c     write solutions.
 c-----------------------------------------------------------------------
-      IF(bin_euler .AND. mod(istep,euler_stride) == 0)THEN
+      IF(bin_euler .AND. (mod(istep,euler_stride) == 0 .OR. force))THEN
          CALL sing_der(neq,psifac,u,du)
          WRITE(euler_bin_unit)1
          WRITE(euler_bin_unit)psifac,q,msol


### PR DESCRIPTION
This overrides the euler_stride skipping of steps when the step is the first or last in a continuous computational region. This means the first step, steps on either sides of the rational surfaces, and the last step are recorded no matter how large euler_stride is.

This is critical for getting consistent results from GPEC. Previously, strides that did not record the final point changed the psifac range, making it inconsistent with psihigh and changing the GPEC plasma response.

Here is a scan of euler_stride in the `DIII-D_ideal_example` before this fix:

|   |   |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/6198372/122626100-629e2780-d05d-11eb-9815-3294c7ff93cb.png) | ![image](https://user-images.githubusercontent.com/6198372/122626160-abee7700-d05d-11eb-9d72-22624ecb15e9.png) |

You can see the cases where the total number of points was not a multiple of euler_stride did not record the edge point, and these are the ones with differences in the core kink structure. This results in big errors for the resonant fields with even small values of euler_stride (more dependent on wether the edge is luckily caught than the actual grid resolution):

Now, we always record the edge point and the GPEC response stays consistent.

|   |   |
| ------------- | ------------- |
![image](https://user-images.githubusercontent.com/6198372/122626216-f5d75d00-d05d-11eb-984d-5051908c7ca1.png) | ![image](https://user-images.githubusercontent.com/6198372/122626256-3931cb80-d05e-11eb-9d55-c12ab2ec39c0.png)

The resonant field does eventually accumulate discrepancies, but it is a regular, linear-ish process and we can get down to a~300 point radial grid (5x reduction) with only ~1% error.

I suspect euler_stride could be much larger in typical cases that use tighter tolerances. This example uses fairly loose tolerances so it runs quickly (only starts with ~1600 pts).

I believe we can regularly use euler_stride=3 now, drastically reducing the memory footprint of euler.bin files and speeding up the slow GPEC profile calculations.
