### PR TITLE
Fixes in OMP for gfortran

### DIFF
--- a/pentrc/torque.F90
+++ b/pentrc/torque.F90
@@ -1409,7 +1409,7 @@ module torque
         !$omp& private(l,wtw_l,trq) &
         !$omp& reduction(+:elems) &
         !$omp& copyin(dbob_m,divx_m,kin,xs_m,fnml, &
-        !$omp& geom, sq, eqfun, rzphi, kin, &
+        !$omp& geom, sq, eqfun, rzphi, &
         !$omp& smats, tmats, xmats, ymats, zmats)
 #ifdef _OPENMP
             IF(first .and. omp_get_thread_num() == 0)then


### PR DESCRIPTION
Minor fixes that make the OpenMP analysis of `gfortran` pass.