### PR TITLE
Better parallel thread defaults

### DIFF
--- a/dcon/dcon.F
+++ b/dcon/dcon.F
@@ -84,9 +84,14 @@ c-----------------------------------------------------------------------
       READ(UNIT=in_unit,NML=dcon_control)
       READ(UNIT=in_unit,NML=dcon_output)
       CALL ascii_close(in_unit)
+
 #ifdef _OPENMP
 c The code is compiled with the OpenMP option so the preprocessor
-c will pick include the following line
+c will include the following lines
+c If the user sets a negative number, use the environment OMP_NUM_THREADS variable
+      IF parallel_threads <= 0 THEN
+         parallel_threads = OMP_GET_MAX_THREADS()
+      ENDIF
       CALL OMP_SET_NUM_THREADS(parallel_threads)
 #else
 c No OpenMP so the following line will appear in source code

--- a/dcon/fourfit.F
+++ b/dcon/fourfit.F
@@ -56,7 +56,7 @@ c-----------------------------------------------------------------------
       COMPLEX(r8), DIMENSION(:,:), POINTER :: asmat,bsmat,csmat
       COMPLEX(r8), DIMENSION(:), POINTER :: jmat
 
-      INTEGER :: parallel_threads
+      INTEGER :: parallel_threads = 1
 
       ! kientic ABCDEH mats for sing_mod
       TYPE(cspline_type) :: kwmats(6),ktmats(6)

--- a/input/dcon.in
+++ b/input/dcon.in
@@ -32,7 +32,7 @@
     ktw = 50.0           ! Parameter activated by ktanh_flag: width of hyper-tangential functions (default: 50.0)
     ion_flag = t         ! Include ion dW_k when kin_flag is true (summed with electron contribution if electron_flag true)
     electron_flag = f    ! Include electron dW_k when kin_flag is true (summed with ion contribution if ion_flag true)
-    parallel_threads=32  ! Parallel calculations of the kinetic matrix components (parallel execution of mpsi*(2*nl+1) calculations where mpsi is set in equil.in and nl in pentrc.in)
+    parallel_threads=1   ! Parallel calculations of the kinetic matrix components (parallel execution of mpsi*(2*nl+1) calculations where mpsi is set in equil.in and nl in pentrc.in)
 
     tol_nr=1e-6          ! Relative tolerance of dynamic integration steps away from rationals
     tol_r=1e-7           ! Relative tolerance of dynamic integration steps near rationals

--- a/input/stride.in
+++ b/input/stride.in
@@ -48,7 +48,7 @@
 /
 
 &stride_params
-    nThreads=32                         ! Number of threads used to calculate intervals in parallel
+    nThreads=1                          ! Number of threads used to calculate intervals in parallel
     fourfit_metric_parallel=f           ! Compute equilibrium metric tensor components in parallel
     vac_parallel=t                      ! Doubles the number of main level threads, creating more threads than processors
 

--- a/stride/dcon_mod.f
+++ b/stride/dcon_mod.f
@@ -98,7 +98,7 @@ c-----------------------------------------------------------------------
       EQUIVALENCE (sas_flag,lim_flag)
       REAL(r8) :: psilim,qlim,q1lim,dmlim=.5_r8,qhigh=1e3,qlow=0
 
-      INTEGER :: nThreads=32
+      INTEGER :: nThreads=1
       LOGICAL :: vac_parallel
 
       CHARACTER(10) :: spline_str

--- a/stride/stride.f
+++ b/stride/stride.f
@@ -243,6 +243,10 @@ c-----------------------------------------------------------------------
 c     prepare code to split: [vac][all else]
 c-----------------------------------------------------------------------
       CALL SYSTEM_CLOCK(COUNT=sTime)
+      ! Enable user to use default number of threads by entering a neg nThreads
+      IF nThreads <= 0 THEN
+         parallel_threads = OMP_GET_MAX_THREADS()
+      ENDIF
       !Note: nThreads+1 code is faster than nThreads.  It allows other
       !      modules to spawn nThreads, despite vac_parallel using 1!
       !      Even if nThread+1 > nProc, experiments suggest it's faster.


### PR DESCRIPTION
DCON & STRIDE - ENHANCEMENT - Improves the logic for the default number of threads

The number of threads from user input is defaulted to 1.
 >> Larger numbers were grabbing up resources even when running serial ideal MHD DCON
 >> We now put the onus of UPING the threads on the user to reduce the prevalence of accidentally greedy jobs

A number of threads of zero or below defaults to the maximum number available
 >> This can be set by a user or admin by setting the OMP_NUM_THREADS env variable
 >> We are putting the onus on cluster admins to properly regulate folks given their available resources