### PR TITLE
Added units for resonant flux/current overlaps in gpec_control_nn.nc

### DIFF
--- a/gpec/gpout.f
+++ b/gpec/gpout.f
@@ -653,7 +653,7 @@ c-----------------------------------------------------------------------
 c     agregate coupling matrices
 c-----------------------------------------------------------------------
       ALLOCATE(singcoup(nsingcoup,msing,mpert))  ! coupling field to external field b_x
-      singcoup(1,:,:) = singbnoflxs        ! effective resonant area-normalized flux (Phi_r/A) shielded by current
+      singcoup(1,:,:) = singbnoflxs        ! effective resonant area-normalized flux (Phi_r/A) shielded by current (Tesla)
       singcoup(2,:,:) = singcurs*twopi*nn  ! resonant current (amps)
       singcoup(3,:,:) = islandhwids        ! square of the penetrated island half-width in normalized poloidal flux
       singcoup(4,:,:) = singbwp            ! interpolated (penetrated) resonant field
@@ -1943,7 +1943,7 @@ c-----------------------------------------------------------------------
             CALL check( nf90_redef(mncid))
             CALL check( nf90_def_var(mncid, "Phi_overlap", nf90_double,
      $         (/m_id,i_id/), p_id) )
-            CALL check( nf90_put_att(mncid, p_id, "units", "unitless") )
+            CALL check( nf90_put_att(mncid, p_id, "units", "Tesla") )
             CALL check( nf90_put_att(mncid, p_id, "long_name",
      $        "Pitch resonant flux overlap") )
             CALL check( nf90_def_var(mncid, "Phi_overlap_norm",
@@ -1953,7 +1953,7 @@ c-----------------------------------------------------------------------
      $        "Pitch resonant flux overlap percentage") )
             CALL check( nf90_def_var(mncid, "I_overlap", nf90_double,
      $         (/m_id,i_id/), c_id) )
-            CALL check( nf90_put_att(mncid, c_id, "units", "unitless") )
+            CALL check( nf90_put_att(mncid, c_id, "units", "Amps") )
             CALL check( nf90_put_att(mncid, c_id, "long_name",
      $        "Pitch resonant current overlap") )
             CALL check( nf90_def_var(mncid, "I_overlap_norm",
@@ -2053,7 +2053,7 @@ c-----------------------------------------------------------------------
                CALL check( nf90_redef(mncid))
                CALL check( nf90_def_var(mncid, "Phi_local_overlap",
      $            nf90_double,(/m_id,i_id/), p_id) )
-               CALL check( nf90_put_att(mncid, p_id,"units","unitless"))
+               CALL check( nf90_put_att(mncid, p_id,"units","Tesla"))
                CALL check( nf90_put_att(mncid, p_id, "long_name",
      $           "Local pitch resonant flux overlap") )
                CALL check( nf90_def_var(mncid, "Phi_local_overlap_norm",
@@ -2063,7 +2063,7 @@ c-----------------------------------------------------------------------
      $           "Local pitch resonant flux overlap percentage") )
                CALL check( nf90_def_var(mncid, "I_local_overlap",
      $            nf90_double,(/m_id,i_id/), c_id) )
-               CALL check( nf90_put_att(mncid, c_id,"units","unitless"))
+               CALL check( nf90_put_att(mncid, c_id,"units","Amps"))
                CALL check( nf90_put_att(mncid, c_id, "long_name",
      $           "Local pitch resonant current overlap") )
                CALL check( nf90_def_var(mncid, "I_local_overlap_norm",

--- a/gpec/gpout.f
+++ b/gpec/gpout.f
@@ -1985,12 +1985,12 @@ c-----------------------------------------------------------------------
      $         (/m_id, i_id/), d_id) )
             CALL check( nf90_put_att(mncid, d_id, "units", "untiless") )
             CALL check( nf90_put_att(mncid, d_id, "long_name",
-     $        "Extrenal Delta prime overlap") )
+     $        "External Delta prime overlap") )
             CALL check( nf90_def_var(mncid, "Delta_overlap_norm",
      $         nf90_double,(/m_id/), dp_id) )
             CALL check( nf90_put_att(mncid, dp_id, "units", "untiless"))
             CALL check( nf90_put_att(mncid, dp_id, "long_name",
-     $        "Extrenal Delta prime overlap percentage") )
+     $        "External Delta prime overlap percentage") )
             CALL check( nf90_enddef(mncid) )
             CALL check( nf90_put_var(mncid, p_id, RESHAPE((/
      $         REAL(olap(1,:)),AIMAG(olap(1,:))/), (/msing,2/))) )


### PR DESCRIPTION
Smalll tweak. I noticed when doing SPARC calculations that these overlaps were not normalized, so I added units for clarity. Let me know if you know what the units should be for "Full width of saturated island overlap," or "Penetrated flux overlap," should be off the top of your head @logan-nc or otherwise I will trace through the code tomorrow afternoon.