### PR TITLE
Stride data race found and fixed

### DIFF
--- a/install/DEFAULTS.inc
+++ b/install/DEFAULTS.inc
@@ -346,6 +346,9 @@ endif
 ifdef MKLROOT
     MATHHOME = $(MKLROOT)
   	MATHLIBS = -lmkl_rt
+else ifdef OPENBLASHOME
+    MATHHOME = $(OPENBLASHOME)
+    MATHLIBS = -lopenblas
 else ifdef LAPACKHOME
     MATHHOME = $(LAPACKHOME)
     MATHLIBS = -llapack -lblas
@@ -353,7 +356,7 @@ else ifdef ACML_HOME
     MATHHOME = $(ACML_HOME)
     MATHLIBS = -lacml
 else
-    $(info "Math libraries require MKLROOT, LAPACKHOME, or ACML_HOME")
+    $(info "Math libraries require MKLROOT, LAPACKHOME, OPENBLASHOME, or ACML_HOME")
 endif
 
 # specifics of which libraries are used

--- a/zlange/makefile
+++ b/zlange/makefile
@@ -1,8 +1,21 @@
 # This is the makefile for ZLANGE.
+# If using gfortran, the proper syntax is -frecursive.
+# If using ifort, the proper syntax is -recursive.
+
+ifneq (,$(findstring ifort,$(FC)))
+    RECURSFLAG=-recursive
+    LEGACYFLAG=
+else ifneq (,$(findstring ifx,$(FC)))
+    RECURSFLAG=-recursive
+    LEGACYFLAG=
+else
+    RECURSFLAG=-frecursive
+    LEGACYFLAG=-std=legacy
+endif
 
 include ../install/DEFAULTS.inc
 
-F90 = $(FC) $(FFLAGS) -I../equil
+F90 = $(FC) $(FFLAGS) $(RECURSFLAG) $(LEGACYFLAG) -I../equil
 
 .f.o:
 	$(F90) -c $*.f


### PR DESCRIPTION
Found this STRIDE data race while testing additions to the netcdf. ZLANGE is not compiled with recursive flags by default and is used in an OpenMP setting, which causes ZLANGE to write over variables other threads are using within ZLANGE. This commit fixes that in the STRIDE makefile, and also adds an environment variable OPENBLASHOME to DEFAULTS.inc to allow users to prefer -lopenblas instead of -llapack -lblas.

I did not look too hard at what section of STRIDE calls zlange within an OpenMP region, that would determine the potential impact on any previous STRIDE results. 

Commit message:
STRIDE, ZLANGE - BUGFIX - STRIDE data race fixed -- non-recursively compiled zlange caused zlange calls in different threads to overwrite each other's private variables. Also added environment variable to DEFAULTS.inc in case users have multiple math libraries installed and want to specify an OpenMP-safe version of OpenBLAS.