### PR TITLE
EQ_TYPE Clarifications

### DIFF
--- a/equil/equil.f
+++ b/equil/equil.f
@@ -122,9 +122,13 @@ c-----------------------------------------------------------------------
       CASE("galkin")
          CALL read_eq_galkin
       CASE("chease")
-         CALL read_eq_chease
+         CALL read_eq_chease_inp1
       CASE("chease2")
-         CALL read_eq_chease2
+         WRITE(*,*) "   !! Warning: eq_type chease2 is deprecated, "//
+     $      "use chease_ascii instead"
+         CALL read_eq_chease_inp1_ascii
+      CASE("chease_ascii")
+         CALL read_eq_chease_inp1_ascii
       CASE("chease3")
          CALL read_eq_chease3
       CASE("chease4")

--- a/equil/equil.f
+++ b/equil/equil.f
@@ -174,10 +174,13 @@ c-----------------------------------------------------------------------
       CASE("t7")
          CALL read_eq_t7
       CASE("marklin_direct")
+         CALL program_stop("Error: Deprecated eq_type "//TRIM(eq_type))
          CALL read_eq_marklin_direct
       CASE("marklin_inverse")
+         CALL program_stop("Error: Deprecated eq_type "//TRIM(eq_type))
          CALL read_eq_marklin_inverse
       CASE("hansen_inverse")
+         CALL program_stop("Error: Deprecated eq_type "//TRIM(eq_type))
          CALL read_eq_hansen_inverse
       CASE("pfrc")
          CALL read_eq_pfrc

--- a/equil/read_eq.f
+++ b/equil/read_eq.f
@@ -298,12 +298,13 @@ c-----------------------------------------------------------------------
       END SUBROUTINE read_eq_miller4
 c-----------------------------------------------------------------------
 c     subprogram 5. read_eq_chease.
-c     reads data from chease.
+c     reads INP1 binary file from chease 
+c     created by setting NIDEAL=3 in chease namelist
 c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
 c     declarations.
 c-----------------------------------------------------------------------
-      SUBROUTINE read_eq_chease
+      SUBROUTINE read_eq_chease_inp1
 
       INTEGER :: ntnova,npsi1,nsym,ma,mtau
       REAL(r8), DIMENSION(5) :: axx
@@ -373,15 +374,17 @@ c-----------------------------------------------------------------------
 c     terminate.
 c-----------------------------------------------------------------------
       RETURN
-      END SUBROUTINE read_eq_chease
+      END SUBROUTINE read_eq_chease_inp1
 c-----------------------------------------------------------------------
-c     subprogram 6. read_eq_chease2.
-c     reads data from chease.
+c     subprogram 6. read_eq_chease_inp1_ascii.
+c     reads INP1_FORMATTED ascii file from chease
+c     created by setting NIDEAL=3, like the standard binary INP1
+c     as of 08/2025, this is only available on custom CHEASE versions
 c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
 c     declarations.
 c-----------------------------------------------------------------------
-      SUBROUTINE read_eq_chease2
+      SUBROUTINE read_eq_chease_inp1_ascii
 
       INTEGER :: ntnova,npsi1,nsym,ma,mtau
       REAL(r8), DIMENSION(5) :: axx


### PR DESCRIPTION
This branch aims to deprecate equilibrium reading routines that should be deprecated because the codes they interfaced with have either officially changed or have been retired. The goal is to prevent users from accidentally using the incorrect `eq_type` due to confusing names that sound like reasonable choices.