### PR TITLE
Adding namelist control over the maximum number of steps in the LSODE integrator inside RDCON

### DIFF
--- a/docs/examples/DIIID_resistive_example/rdcon.in
+++ b/docs/examples/DIIID_resistive_example/rdcon.in
@@ -2,6 +2,7 @@
     nx=256               ! The number of elements in each interval between two singular surfaces
     pfac=0.001           ! Packing ratio near the singular surface
     gal_tol=1e-10        ! Tolerance of lsode integration
+    gnstep=5000          ! Maximum number of steps of lsode integrator
     dx1dx2_flag=t        ! Flag to include the special dx1 and dx2 treatments for resonant and extension element
     dx0=5e-4             ! The distance to the singular surface to truncate the lsode integration in resonant element
     dx1=1.e-3            ! The size of resonant element

--- a/docs/examples/a5_tearing_example/rdcon.in
+++ b/docs/examples/a5_tearing_example/rdcon.in
@@ -2,6 +2,7 @@
     nx=256               ! The number of elements in each interval between two singular surfaces
     pfac=0.001           ! Packing ratio near the singular surface
     gal_tol=1e-10        ! Tolerance of lsode integration
+    gnstep=5000          ! Maximum number of steps of lsode integrator
     dx1dx2_flag=t        ! Flag to include the special dx1 and dx2 treatments for resonant and extension element
     dx0=5e-4             ! The distance to the singular surface to truncate the lsode integration in resonant element
     dx1=1.e-3            ! The size of resonant element

--- a/docs/examples/solovev_resistive_example/rdcon.in
+++ b/docs/examples/solovev_resistive_example/rdcon.in
@@ -2,6 +2,7 @@
     nx=256               ! The number of elements in each interval between two singular surfaces
     pfac=0.001           ! Packing ratio near the singular surface
     gal_tol=1e-10        ! Tolerance of lsode integration
+    gnstep=5000          ! Maximum number of steps of lsode integrator
     dx1dx2_flag=t        ! Flag to include the special dx1 and dx2 treatments for resonant and extension element
     dx0=5e-4             ! The distance to the singular surface to truncate the lsode integration in resonant element
     dx1=1.e-3            ! The size of resonant element

--- a/input/rdcon.in
+++ b/input/rdcon.in
@@ -2,6 +2,7 @@
     nx=256               ! The number of elements in each interval between two singular surfaces
     pfac=0.001           ! Packing ratio near the singular surface
     gal_tol=1e-10        ! Tolerance of lsode integration
+    gnstep=5000          ! Maximum number of steps of lsode integrator
     dx1dx2_flag=t        ! Flag to include the special dx1 and dx2 treatments for resonant and extension element
     dx0=5e-4             ! The distance to the singular surface to truncate the lsode integration in resonant element
     dx1=1.e-3            ! The size of resonant element

--- a/rdcon/gal.f
+++ b/rdcon/gal.f
@@ -89,6 +89,7 @@ c-----------------------------------------------------------------------
       INTEGER, PRIVATE :: jsing,np=3
       REAL(r8) :: dx0,dx1,dx2,pfac
       REAL(r8) :: gal_tol=1e-10
+      INTEGER  :: gnstep=5000
       LOGICAL :: gal_xmin_flag = .FALSE.
       REAL(r8), DIMENSION(0:2) :: gal_eps_xmin = (/1e-2,1e-6,5e-7/)
       TYPE(cell_type), POINTER, PRIVATE :: cell
@@ -775,7 +776,6 @@ c-----------------------------------------------------------------------
 
       LOGICAL, PARAMETER :: diagnose=.FALSE.
       CHARACTER(16) :: name
-      INTEGER :: nstep
       INTEGER :: neq,itol,itask,istate,iopt,lrw,liw,jac,mf,istep
       INTEGER, DIMENSION(:), ALLOCATABLE :: iwork
       REAL(r8) :: rtol,atol
@@ -797,7 +797,6 @@ c-----------------------------------------------------------------------
       iopt=1
       
       istep=0
-      nstep=5000
       rtol=gal_tol
       atol=gal_tol
 c-----------------------------------------------------------------------
@@ -857,13 +856,13 @@ c-----------------------------------------------------------------------
          dt=rwork(11)/dx
          IF(diagnose_lsode)
      $        CALL gal_lsode_diagnose(neq,istep,x0,x1,x,t,dt,u)
-         IF(ABS(t-1) < gal_tol .OR. istep >= nstep)EXIT
+         IF(ABS(t-1) < gal_tol .OR. istep >= gnstep)EXIT
          istep=istep+1
          CALL lsode(gal_lsode_der,neq,u,x,x1,itol,rtol,atol,
      $        itask,istate,iopt,rwork,lrw,iwork,liw,jac,mf)
       ENDDO
-      IF (istep >= nstep) THEN 
-         WRITE (*,*)"Warning: LSODE exceeds nstep."
+      IF (istep >= gnstep) THEN 
+         WRITE (*,*)"Warning: LSODE exceeds gnstep:",gnstep
          WRITE (*,*)"  ABS(t-1)=",ABS(t-1)," > gal_tol=",gal_tol
       ENDIF
       IF(cell%extra == "right")u=-u
@@ -1688,7 +1687,7 @@ c-----------------------------------------------------------------------
       NAMELIST/gal_input/nx,nq,dx0,dx1,dx2,pfac,diagnose_map,solver,
      $     diagnose_grid,diagnose_lsode,ndiagnose,diagnose_integrand,
      $     diagnose_mat,gal_tol,dx1dx2_flag,cutoff,prefac,dpsi_intvl,
-     $     dpsi1_intvl,gal_xmin_flag,gal_eps_xmin
+     $     dpsi1_intvl,gal_xmin_flag,gal_eps_xmin,gnstep
       NAMELIST /gal_output/interp_np,restore_uh,restore_us,
      $     restore_ul,bin_delmatch,out_galsol,bin_galsol,b_flag,
      $     bin_coilsol


### PR DESCRIPTION
If as you lower gal_tol in rdcon.in, at large values of psihigh, often you run into an issue where the LSODE integrator inside gal.f (that computes the galerkin basis function using the asymptotic form of the ideal solution) runs out of steps:
<img width="682" height="851" alt="Screenshot 2026-03-01 at 9 21 44 PM" src="https://github.com/user-attachments/assets/6e63c67f-46c9-40a4-a1b1-f81a727a7e79" />

A user may wish to increase the maximum number of steps, so that their input gal_tol can be realised. 