### PR TITLE
GPEC_SLAYER - Fix rs, shear, and b_l normalization bugs

### DIFF
--- a/gpec/gpout.f
+++ b/gpec/gpout.f
@@ -1618,7 +1618,7 @@ c-----------------------------------------------------------------------
 
       REAL(r8), DIMENSION(msing) :: b_crit, ti_r, te_r, ni_r, ne_r,
      $    q1_r, we_r, wi_r, rh_r, r1_r
-      REAL(r8) :: omega_i,omega_e,jxb,omega_sol,br_th
+      REAL(r8) :: omega_i,omega_e,jxb,omega_sol,br_th,slayer_shear
       COMPLEX(r8) :: delta_s,psi0
 
 c-----------------------------------------------------------------------
@@ -1866,9 +1866,11 @@ c-----------------------------------------------------------------------
 c     compute threshold by linear drift mhd with slayer module.
 c-----------------------------------------------------------------------
          IF (slayer_threshold_flag) THEN
+            ! True shear s=(r/q)*dq/dr via rhotor Jacobian
+            slayer_shear=(sr%f(1)/sq%f(4))*sq%f1(4)/sr%f1(1)
             CALL gpec_slayer(kin%f(2),kin%f(4)/e,kin%f(1),kin%f(3)/e,
-     $           kin%f(9),kin%f(5),omega_e,omega_i,sq%f(4),sq%f1(4),
-     $           bt0,sr%f1(1),ro,mi,slayer_inpr,resm,nn,ascii_flag,
+     $           kin%f(9),kin%f(5),omega_e,omega_i,sq%f(4),slayer_shear,
+     $           bt0,sr%f(1),ro,mi,slayer_inpr,resm,nn,ascii_flag,
      $           delta_s,psi0,jxb,omega_sol,br_th)
             b_crit(ising)=br_th  ! Tesla. Normal resonant field comparable to singflx
          ENDIF

--- a/slayer/gslayer.f
+++ b/slayer/gslayer.f
@@ -73,7 +73,7 @@ c-----------------------------------------------------------------------
       eta= 1.65e-9*lnLamb/(t_e/1e3)**1.5 ! spitzer resistivity (wesson)
       rho=(mu_i*m_p)*n_e               ! mass density
 
-      b_l=(nrs/mrs)*nrs*sval*bt/R0     ! characteristic magnetic field
+      b_l=(nrs/mrs)*rs*sval*bt/R0      ! characteristic magnetic field
       v_a=b_l/(mu0*rho)**0.5           ! alfven velocity
       rho_s=1.02e-4*(mu_i*t_e)**0.5/bt ! ion Lamour by elec. Temp.
 


### PR DESCRIPTION
## Summary

- **Fix 1 (`gpout.f`):** Pass `sr%f(1)` (rhotor value at resonant surface) as `rs` to `gpec_slayer` instead of `sr%f1(1)` (drhotor/dpsi_n, the Jacobian). The derivative is ~2× larger than the actual minor radius, causing `tau_r` and `lu` to be ~4× too high and suppressing `b_crit` by ~2× for all cases.
- **Fix 2 (`gpout.f`):** Compute the true dimensionless magnetic shear `s = (r/q)*dq/dr` as `slayer_shear = (sr%f(1)/sq%f(4))*sq%f1(4)/sr%f1(1)` and pass that instead of raw `sq%f1(4) = dq/dpsi_n`, which overestimates the shear by a factor of ~2q.
- **Fix 3 (`gslayer.f`):** Correct dead-code `b_l` formula from `(nrs/mrs)*nrs*sval*bt/R0` to `(nrs/mrs)*rs*sval*bt/R0`, matching `params.f`. No effect on results since `b_l` is never used in the threshold calculation.

## Test plan

- [ ] Compile with existing build system and confirm no errors
- [ ] Run a standard DIII-D test case with `slayer_threshold_flag=T` and compare `b_crit` values before/after (expect ~2× increase from the `rs` fix)
- [ ] Verify `slayer_shear` is physically reasonable (O(1) dimensionless) for test cases
- [ ] Run the high-bt (~10T) case that motivated this investigation and check `b_crit` behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)