### PR TITLE
Fix xdraw implicit function declarations for C99/C11 compliance

### DIFF
--- a/xdraw/binread.h
+++ b/xdraw/binread.h
@@ -1,0 +1,2 @@
+void tell_buffer();
+void tell_array();

--- a/xdraw/event.c
+++ b/xdraw/event.c
@@ -69,18 +69,12 @@ extern float *buf;
 #include "xinit.h"
 #include "xedit.h"
 #include "setcolor.h"
+#include "binread.h"
 
 extern void postscript(char *);	/* near heap problem, try elim .h's*/
 extern float get_world(int, int, XRectangle, float, float, float, float,
 		       float*, float*);
 extern int nearest_M_value(float, float, CURVE_SET *, char *, double *);
-
-extern void tell_buffer();
-extern void tell_array();
-extern int new_nvect(CURVE_SET *, char);
-extern void toggle_markersize(CURVE_SET *);
-extern void redraw_dialog();
-extern void get_world_coordinates(int, int, double *, double *, char *);
 
 #ifdef USE_MENU
 #include "device.h"

--- a/xdraw/pspack.c
+++ b/xdraw/pspack.c
@@ -19,6 +19,7 @@
 #include <sys/stat.h>
 
 #include "pspack.h"
+#include "ps.h"
 
 #define FZ (float)0
 
@@ -26,10 +27,6 @@ FILE *file, *frd;
 int wdx, wdy, wbord;
 extern int ps_aspect;
 char outfile[40] = "";
-extern void ps_country(int);
-extern int get_maxps();
-extern void ps_layout(int, int, int);
-extern void writetrf(FILE *, FILE *, int, int, int, int, int, int);
 /*-----------------------------------------------------------------------------
 |   main
 -----------------------------------------------------------------------------*/

--- a/xdraw/setcolor.c
+++ b/xdraw/setcolor.c
@@ -8,10 +8,10 @@
 **  Copyright (c) CounterPoint Graphics 1993.  All rights reserved.
 ******************************************************************************/
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 
-#include <stdlib.h>
 #include <unistd.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
@@ -20,6 +20,7 @@
 
 #include "setcolor.h"
 #include "ps.h"
+#include "xtools.h"
 
 #define XPRINTF
 #include "gendefs.h"
@@ -34,8 +35,6 @@ extern Colormap cmap;
 extern int dialogwindow;
 extern Window dialog_win;
 extern GC dialog_gc;
-
-extern void get_properties(Window, unsigned int *, unsigned int *, unsigned int *);
 
 static XColor xcolor;
 

--- a/xdraw/setcolor.h
+++ b/xdraw/setcolor.h
@@ -13,7 +13,4 @@ extern int getgoodfont (char *fonttitle,int lowpoint,int highpoint,
 			char *searchfontname);
 int SetShades(double hue, double chroma,long *pixels, int n);
 int AllocShades(long *pixels, int n, int k);
-
-
-
-
+void redraw_dialog();

--- a/xdraw/spline1.h
+++ b/xdraw/spline1.h
@@ -1,0 +1,6 @@
+#define Float double
+
+void splfit(Float *xs, Float *fs, Float *fs1, int m);
+void spleval(Float *xs, Float *fs, Float *fs1,
+	     Float *f, Float *f1, Float *f2, Float *f3,
+	     Float x, int m, int mmax, int nqty, int mode);

--- a/xdraw/xcontour.c
+++ b/xdraw/xcontour.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #if !defined(__MACH__)
-#include <stdlib.h>
+#include <malloc.h>
 #endif
 #include <string.h>
 #include <math.h>
@@ -69,6 +69,7 @@ typedef struct
 #include "xtools.h"
 #include "setcolor.h"
 #include "ps.h"
+#include "spline1.h"
 
 #define FZ (float)0
 
@@ -157,8 +158,6 @@ extern FloatSc xscale, xoffset, yscale, yoffset;
 static FloatSc rscale, roffset, zscale, zoffset;
 extern int wx0,wy0;
 extern int myscreen;
-extern void splfit(Float *, Float *, Float *, int);
-extern void spleval(Float *, Float *, Float *, Float *, Float *, Float *, Float*, Float, int, int, int, int);
 
 static int isep = -1;
 static int ncurve=32, last_ncurve, hzcurve=0;

--- a/xdraw/xcontour.h
+++ b/xdraw/xcontour.h
@@ -8,6 +8,8 @@ extern void redraw_mb(CURVE_SET *cp,
 extern	int new_ncurve(CURVE_SET *cp, char how);
 extern  void contour_values(CURVE_SET *cp);
 extern	void get_contlim(float *xlim, float *ylim);
+int new_nvect(CURVE_SET *cp, char how);
+void get_world_coordinates(int i, int which,  double *x, double *y, char *caption);
 
 #ifdef XCONTOUR
 extern  void drawcontour(float psi,int ii);
@@ -42,7 +44,6 @@ extern int FindPoint( float x1, float y1, float z1,
 	       float *xp, float *yp   );
 extern void drawcontour_t(float psi, int ii,int xy_off,int f_off,
 		   int mvert,int mcells);
-int new_nvect(CURVE_SET *cp, char how);
 void draw_v(int mr,int mz,int x_off,int y_off,int q1_off,int q2_off,
 	    float *lmax, int *npoints, int *zpoints,
 	    float l_scale, int mod, int density);

--- a/xdraw/xdraw.h
+++ b/xdraw/xdraw.h
@@ -37,4 +37,4 @@ extern void label(float *xlim, FloatSc xscale, FloatSc xoffset,
 	  float *ylim, FloatSc yscale, FloatSc yoffset, CURVE_SET *cp);
 extern int load_single_label(CURVE_SET *cp, char *string);
 extern int rand_label(int);
-
+void toggle_markersize(CURVE_SET *cp1);

--- a/xdraw/xinit.h
+++ b/xdraw/xinit.h
@@ -11,6 +11,7 @@ extern void get_limits(CURVE_SET *cp);
 extern int parse_title(CURVE_SET *cp, char *title, char *text);
 extern int parse_subtitle(CURVE_SET *, char *);
 extern char *to_greek(char *str,int *res);
+void settextcolor(int i);
 
 extern int m_lang_str(char *str,XTextItem *pnt_lang,int *n_items);
 #define AXIS_WIDTH 1

--- a/xdraw/xtools.c
+++ b/xdraw/xtools.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #if !defined(__MACH__)
-#include <stdlib.h>
+#include <malloc.h>
 #endif
 #include <string.h>
 #include <fcntl.h>

--- a/xdraw/xtools.h
+++ b/xdraw/xtools.h
@@ -1,6 +1,8 @@
 /*-----------------------------------------------------------------------------
 |	xtools.h
 -----------------------------------------------------------------------------*/
+typedef int byte;
+
 extern void give_command_args(int, char**);
 extern int opendisplay(char *title);
 extern void closedisplay(void);


### PR DESCRIPTION
## Summary

Move bare `extern` function declarations from `.c` files into proper
headers so xdraw compiles without implicit function declaration errors
on strict C99/C11 compilers.

### Changes
- New `binread.h`: declarations for `tell_buffer()`, `tell_array()`
- New `spline1.h`: declarations for `splfit()`, `spleval()`
- `event.c`: include `binread.h`, remove bare `extern` block
- `pspack.c`: include `ps.h`, remove bare `extern` block
- `setcolor.c`: include `xtools.h`, reorder `stdlib.h`, remove bare `extern`
- `setcolor.h`: add `redraw_dialog()` prototype
- `xcontour.c`: include `spline1.h`, fix duplicate `stdlib.h` to `malloc.h`, remove bare `extern`
- `xcontour.h`: add `new_nvect()`, `get_world_coordinates()` prototypes, remove duplicate
- `xdraw.h`: add `toggle_markersize()` prototype
- `xinit.h`: add `settextcolor()` prototype
- `xtools.c`: fix duplicate `stdlib.h` to `malloc.h`
- `xtools.h`: add `typedef int byte`

### Motivation
Intel icx 2025 treats implicit function declarations as errors per C99/C11.
GCC emits warnings but compiles. This moves declarations into headers,
making xdraw compile cleanly on both.

No whitespace-only changes. No Fortran changes. Rebased on develop after #255.

## Test plan
- [x] gfortran 15.2 build + DIII-D ideal/resistive examples pass
- [x] Intel icx 2025 build + DIII-D ideal/resistive examples pass
- [x] Physics output identical to develop