### PR TITLE
Remove trailing whitespace in pentrc source files

### DIFF
--- a/pentrc/dcon_interface.f
+++ b/pentrc/dcon_interface.f
@@ -31,7 +31,7 @@ c-----------------------------------------------------------------------
      $                       bicube_eval_external
       USE params, only : r4,r8,pi,twopi,mu0
       USE utilities, only : get_free_file_unit,iscdftb,iscdftf
-      
+
       IMPLICIT NONE
 
       LOGICAL :: edge_flag=.FALSE.,fft_flag=.FALSE.,
@@ -469,7 +469,7 @@ c-----------------------------------------------------------------------
             u2%fs(istep,:)=MATMUL(soltype(istep)%u(:,1:mpert,2),temp1)
             u3%fs(istep,:)=MATMUL(soltype(istep)%u(:,1:mpert,3),temp1)
             u4%fs(istep,:)=MATMUL(soltype(istep)%u(:,1:mpert,4),temp1)
-         ENDDO         
+         ENDDO
          jfix=kfix+1
       ENDDO
 c-----------------------------------------------------------------------
@@ -499,7 +499,7 @@ c-----------------------------------------------------------------------
       INTEGER :: ipsi,itheta,out_unit
       REAL(r8) :: w11,w12,delpsi,qintb,val1,val2,
      $      q,rfac,eta,jac,jac1
-      
+
       REAL(r8), DIMENSION(0:mpsi) :: psitor
       REAL(r8), DIMENSION(0:mpsi,0:mtheta) :: rs,zs,jacb2
       REAL(r8), DIMENSION(3,3) :: w,v
@@ -605,7 +605,7 @@ c-----------------------------------------------------------------------
       qs%fs(1:mpsi+1,1)=sq%fs(:,4)
       CALL spline_eval(sq,val2,0)
       qs%fs(mpsi+2,1)=sq%f(4)
-      CALL spline_fit(qs,"extrap") 
+      CALL spline_fit(qs,"extrap")
       CALL spline_int(qs)
       qintb=qs%fsi(mpsi+2,1)
       psitor(:)=qs%fsi(1:mpsi+1,1)/qintb
@@ -615,30 +615,30 @@ c-----------------------------------------------------------------------
       OPEN(UNIT=out_unit,FILE="idcon_equil.out",STATUS="UNKNOWN")
       WRITE(out_unit,*)"IDCON_EQUIL: "//
      $     "Various equilibrium quantities"
-      WRITE(out_unit,*)     
+      WRITE(out_unit,*)
       WRITE(out_unit,'(1x,a13,a8)')"jac_type = ",jac_type
       WRITE(out_unit,'(2(1x,a8,1x,I6))')"mpsi =",mpsi,"mtheta =",mtheta
       WRITE(out_unit,'(2(1x,a14,1x,es16.8))')"psi_edge =",psio,
      $     "psitor_edge =",qintb*psio
-      WRITE(out_unit,*)     
+      WRITE(out_unit,*)
       WRITE(out_unit,*)" Flux functions:"
-      WRITE(out_unit,*) 
+      WRITE(out_unit,*)
       WRITE(out_unit,'(6(1x,a16))')"psi","psitor","p","q","g","I"
       DO ipsi=0,mpsi
          CALL spline_eval(sq,sq%xs(ipsi),0)
          CALL spline_alloc(qs,mtheta,1)
          qs%xs=rzphi%ys
          qs%fs(:,1)=jacb2(ipsi,:)
-         CALL spline_fit(qs,"periodic") 
-         CALL spline_int(qs)          
+         CALL spline_fit(qs,"periodic")
+         CALL spline_int(qs)
          WRITE(out_unit,'(6(1x,es16.8))')sq%xs(ipsi),psitor(ipsi),
      $        sq%f(2)/mu0,sq%f(4),sq%f(1)/(twopi*mu0),
      $        (qs%fsi(mtheta,1)/(twopi*chi1)-sq%f(4)*sq%f(1)/twopi)/mu0
          CALL spline_dealloc(qs)
       ENDDO
-      WRITE(out_unit,*)     
+      WRITE(out_unit,*)
       WRITE(out_unit,*)" 2D functions:"
-      WRITE(out_unit,*)  
+      WRITE(out_unit,*)
       WRITE(out_unit,'(8(1x,a16))')"psi","theta","r","z",
      $     "eta","dphi","jac","b0"
       DO ipsi=0,mpsi
@@ -801,7 +801,7 @@ c-----------------------------------------------------------------------
      $        ", ipert = ",info,", reduce delta_mband"
          !CALL gpec_stop(message)
          PRINT *,message
-         STOP         
+         STOP
       ENDIF
 c-----------------------------------------------------------------------
 c     store hermitian matrices fg.
@@ -868,7 +868,7 @@ c-----------------------------------------------------------------------
       REAL(r8) :: psi,angle,rs,
      $     g12,g22,g13,g23,g33,singfac2,b2h,b2hp,b2ht,
      $     p1,q,rfac,eta,jac,jac1
-      COMPLEX(r8), DIMENSION(-mband:mband) :: 
+      COMPLEX(r8), DIMENSION(-mband:mband) ::
      $     sband,tband,xband,yband1,yband2,zband1,zband2,zband3
       COMPLEX(r8), DIMENSION(mpert,mpert) :: smat,tmat,xmat,ymat,zmat
       REAL(r8), DIMENSION(3,3) :: w,v
@@ -935,7 +935,7 @@ c-----------------------------------------------------------------------
             g22=SUM(v(2,:)**2)
             g23=v(2,3)*v(3,3)
             g33=v(3,3)*v(3,3)
-            
+
             fmodb%fs(ipsi,itheta,1)=jac*(p1+b2hp)
      $           -chi1**2*b2ht*(g12+q*g13)/(jac*b2h*2)
             fmodb%fs(ipsi,itheta,2)=
@@ -958,7 +958,7 @@ c-----------------------------------------------------------------------
       ENDIF
 
       DO ipsi=0,mpsi
-         
+
          q=sq%fs(ipsi,4)
          sband(0:-mband:-1)=fmodb%cs%fs(ipsi,1:mband+1)
          tband(0:-mband:-1)=fmodb%cs%fs(ipsi,mband+2:2*mband+2)
@@ -1070,7 +1070,7 @@ c-----------------------------------------------------------------------
       END FUNCTION issect
 c-----------------------------------------------------------------------
 c     subprogram 9. idcon_coords.
-c     transform coordinates to dcon coordinates. 
+c     transform coordinates to dcon coordinates.
 c-----------------------------------------------------------------------
       SUBROUTINE idcon_coords(psi,ftnmn,amf,amp,ri,bpi,bi,rci,ti,ji)
 c-----------------------------------------------------------------------
@@ -1089,8 +1089,8 @@ c-----------------------------------------------------------------------
       COMPLEX(r8), DIMENSION(0:mthsurf) :: ftnfun
       REAL(r8), DIMENSION(3,3) :: w
 
-      TYPE(spline_type) :: spl     
-      
+      TYPE(spline_type) :: spl
+
       CALL spline_alloc(spl,mthsurf,2)
       spl%xs=theta
 
@@ -1114,11 +1114,11 @@ c-----------------------------------------------------------------------
      $        bpfac**bpi*bfac**bi
          ! jacobian for coordinate angle at dcon angle
          spl%fs(itheta,2)=delpsi(itheta)*r(itheta)**ri*rfac**rci/
-     $        (bpfac**bpi*bfac**bi)  
+     $        (bpfac**bpi*bfac**bi)
          IF (ti .EQ. 0) THEN
             dphi(itheta)=rzphi%f(3)
          ENDIF
-      ENDDO      
+      ENDDO
 
       CALL spline_fit(spl,"periodic")
       CALL spline_int(spl)
@@ -1139,10 +1139,10 @@ c-----------------------------------------------------------------------
          CALL iscdftb(amf,amp,ftnfun,mthsurf,ftnmn)
          ftnfun=ftnfun/jacfac*jarea
          CALL iscdftf(amf,amp,ftnfun,mthsurf,ftnmn)
-      ENDIF         
+      ENDIF
 c-----------------------------------------------------------------------
 c     convert coordinates.
-c-----------------------------------------------------------------------      
+c-----------------------------------------------------------------------
       ! compute given function in dcon angle
       DO itheta=0,mthsurf
          ftnfun(itheta)=0
@@ -1421,8 +1421,8 @@ c-----------------------------------------------------------------------
      $              set_smats,set_tmats,set_xmats,set_ymats,set_zmats,
      $              set_chi1,set_ro,set_nn,set_jac_type,
      $              set_mlow,set_mhigh,set_mpert,set_mthsurf)
-      !----------------------------------------------------------------------- 
-      !*DESCRIPTION: 
+      !-----------------------------------------------------------------------
+      !*DESCRIPTION:
       !   Set the dcon equilibrium global variables directly. For internal use
       !   within kinetic dcon.
       !
@@ -1449,21 +1449,21 @@ c-----------------------------------------------------------------------
       !       Number grid intervals in theta
       !
       !-----------------------------------------------------------------------
-    
+
         implicit none
         ! declare arguments
         integer :: set_mlow,set_mhigh,set_mpert,set_nn,set_mthsurf
         real(r8) :: set_ro,set_chi1
         !real(r8), dimension(:) :: set_psifac
         character(*), intent(in) :: set_jac_type
-        
+
         type(spline_type) :: set_sq
         type(bicube_type) :: set_eqfun,set_rzphi
         type(cspline_type) :: set_smats,set_tmats,set_xmats,
      $      set_ymats,set_zmats
-        
+
         integer :: m
-        
+
         ! directly transfer dcon global equilibrium variables to PENTRC
         eqfun   =set_eqfun
         sq      =set_sq
@@ -1471,7 +1471,7 @@ c-----------------------------------------------------------------------
         mpsi = sq%mx
 
         ! needed to create w_i^T*w_j coefficient matices
-        smats   =set_smats 
+        smats   =set_smats
         tmats   =set_tmats
         xmats   =set_xmats
         ymats   =set_ymats
@@ -1489,12 +1489,12 @@ c-----------------------------------------------------------------------
         ! evaluate field on axis
         call spline_eval(sq,0.0_r8,0)
         bo = abs(sq%f(1))/(twopi*ro)
-        
+
         ! set additional geometric spline
         call set_geom
 
       end subroutine set_eq
-      
+
 c-----------------------------------------------------------------------
 c     subprogram idcon_harvest.
 c     log inputs with harvest.

--- a/pentrc/inputs.f90
+++ b/pentrc/inputs.f90
@@ -1,8 +1,8 @@
 !@PERTURBED EQUILIBRIUM NONAMBIPOLAR TRANSPORT CODE
 
 module inputs
-    !----------------------------------------------------------------------- 
-    !*DESCRIPTION: 
+    !-----------------------------------------------------------------------
+    !*DESCRIPTION:
     !   Input interface for PENTRC. Includes DCON interface developed by
     !   J.-K. Park in GPEC package, as well as ascii interfaces for
     !   kinetic profiles and perturbed equilibrium files.
@@ -28,7 +28,7 @@ module inputs
     ! AUTHOR: Logan
     ! EMAIL: nikolas.logan@columbia.edu
     !-----------------------------------------------------------------------
-    
+
     use params, only : r8,xj,mp,me,e,mu0,twopi
     use utilities, only : get_free_file_unit,readtable,nunique,progressbar,iscdftf,iscdftb
     use spline_mod, only : spline_type,spline_alloc,spline_fit,spline_eval,spline_write1
@@ -36,7 +36,7 @@ module inputs
                             cspline_fit,cspline_write,cspline_eval
     use fspline_mod, only : fspline_eval
     use bicube_mod, only : bicube_type,bicube_alloc,bicube_fit,bicube_eval
-    
+
     use dcon_interface, only : idcon_read,idcon_transform,idcon_metric,&
         idcon_matrix,idcon_action_matrices,idcon_build,set_geom,idcon_harvest,&
         geom,eqfun,sq,rzphi,smats,tmats,xmats,ymats,zmats,amat,bmat,cmat,&
@@ -45,9 +45,9 @@ module inputs
         mfac,psifac,mpert,mstep,mthsurf,theta,&
         idcon_coords,&
         verbose
-    
+
     implicit none
-    
+
     private
     public &
         read_kin, &
@@ -62,7 +62,7 @@ module inputs
         chi1,ro,zo,bo,nn,mfac,mpert,mthsurf, &
         shotnum,shottime,machine,&
         verbose
-    
+
     ! global variables with defaults
     type(spline_type) :: kin
     type(cspline_type) :: dbob_m, divx_m, xs_m(3)
@@ -122,8 +122,8 @@ module inputs
 
     !=======================================================================
     subroutine read_equil(file,hlog)
-    !----------------------------------------------------------------------- 
-    !*DESCRIPTION: 
+    !-----------------------------------------------------------------------
+    !*DESCRIPTION:
     !   Read dcon binary and form all the equilibrium splines.
     !
     !*ARGUMENTS:
@@ -131,7 +131,7 @@ module inputs
     !       File path.
     !
     !-----------------------------------------------------------------------
-    
+
         implicit none
         ! declare arguments
         character(*), intent(in) :: file
@@ -155,12 +155,12 @@ module inputs
         WRITE(*,*)chi1
 
     end subroutine read_equil
-    
-    
+
+
     !=======================================================================
     subroutine read_kin(file,zi,zimp,mi,mimp,nfac,tfac,wefac,wpfac,write_log)
-    !----------------------------------------------------------------------- 
-    !*DESCRIPTION: 
+    !-----------------------------------------------------------------------
+    !*DESCRIPTION:
     !   Read ascii file containing table of kinetic profiles ni, ne, ti,
     !   te, and omegaE, then form kin spline containing some additional
     !   information (krook nui,nue).
@@ -187,9 +187,9 @@ module inputs
     !       Scaling of rotation profile, done via manipulation of omegaE
     !   write_log : bool
     !       Writes kinetic spline to log file
-    !   
+    !
     !-----------------------------------------------------------------------
-    
+
         implicit none
         ! declare arguments
         character(512), intent(in) :: file
@@ -200,17 +200,17 @@ module inputs
         logical :: warning_printed = .false.
         real(r8), dimension(:,:), allocatable :: table
         character(32), dimension(:), allocatable :: titles
-        
+
         integer, parameter :: nkin = 100
         integer :: i,out_unit, tshape(2)
         real(r8) :: psi
         real(r8), dimension(0:nkin) :: zeff,zpitch,welec,wdian,wdiat,wpefac
         type(spline_type) :: tmp
-        
+
         call readtable(file,table,titles,verbose,write_log)
         tshape = shape(table)
         if(write_log) print *,"Table shaped ",tshape
-        
+
         ! temp spline on experimental grid
         call spline_alloc(tmp,tshape(1)-1,5)
         tmp%xs(0:) = table(1:,1)
@@ -247,7 +247,7 @@ module inputs
 
         call spline_fit(kin,"extrap")
         if(write_log) print *,"Formed kin spline"
-    
+
         ! manipulation of N and T profiles
         kin%fs(:,1:2) = nfac*kin%fs(:,1:2)
         kin%fs(:,3:4) = tfac*kin%fs(:,3:4)
@@ -626,7 +626,7 @@ module inputs
             xmsmni(:,:) = reshape(table(:,7),(/npsi,nm/),order=(/1,2/))&
                     +xj*reshape(table(:,8),(/npsi,nm/),order=(/1,2/))
         endif
-        
+
         ! convert to chebyshev coordinates
         if(jac_in=="" .or. jac_in=="default")then
             jac_in = jac_type
@@ -735,16 +735,16 @@ module inputs
         ! set global variables (perturbed quantity csplines)
         call set_peq(psi(ipsilow:ipsihigh),mfac,xmp1mns(ipsilow:ipsihigh,:),xspmns(ipsilow:ipsihigh,:),&
                      xmsmns(ipsilow:ipsihigh,:),.true.,debug)
-        
+
         deallocate(ms,psi,xmp1mns,xspmns,xmsmns)
-        
+
     end subroutine read_peq
-    
-    
+
+
     !=======================================================================
     subroutine set_peq(psi,ms,xmp1mns,xspmns,xmsmns,op_set_dbdx,op_debug)
-    !----------------------------------------------------------------------- 
-    !*DESCRIPTION: 
+    !-----------------------------------------------------------------------
+    !*DESCRIPTION:
     !   Set m quantity xs_m complex splines in psi for the 2 Clebsch
     !   displacement components from 2D (psi,m) distributions.
     !   **This routine sets global variables xs_m dbob_m and divx_m**
@@ -765,14 +765,14 @@ module inputs
     !       them to global complex spline variable dbob_m,divx_m. (Defaut True)
     !   op_debug : logical
     !       Print intermidient messages to terminal. (Default False)
-    !       
+    !
     !-----------------------------------------------------------------------
-    
+
         implicit none
-        
+
         ! declare arguments
         logical, intent(in), optional :: op_debug,op_set_dbdx
-        integer,  dimension(:), intent(in) :: ms        
+        integer,  dimension(:), intent(in) :: ms
         real(r8), dimension(:), intent(in) :: psi
         complex(r8), dimension(:,:), intent(in) :: xmp1mns,xspmns,xmsmns
         ! declare local variables
@@ -782,7 +782,7 @@ module inputs
         complex(r8), dimension(mpert,mpert) :: smat,tmat,xmat,ymat,zmat
         complex(r8), dimension(:,:), allocatable :: jbbkapxmns,jbbdivxmns,jbbdbobmns
         character(3) :: istring
-        
+
         ! defaults for optional args
         debug = .false.
         set_dbdx = .true.
@@ -793,7 +793,7 @@ module inputs
         istop_psi = UBOUND(psi,1)
         npsi = size(psi)
         nm = size(ms)
-        
+
         ! set global variables
         if(debug) print *,"  Setting global perturbed xi variables"
         !if(debug) print *,"  nm,mpert",nm,mpert
@@ -810,7 +810,7 @@ module inputs
         enddo
         do i =1,mpert
             ims = i+(mfac(1)-ms(1))
-            if(ims>0 .and. ims<=nm)then        
+            if(ims>0 .and. ims<=nm)then
                 xs_m(1)%fs(0:,i) =xmp1mns(1:,ims)
                 xs_m(2)%fs(0:,i) = xspmns(1:,ims)
                 xs_m(3)%fs(0:,i) = xmsmns(1:,ims)
@@ -909,8 +909,8 @@ module inputs
 
     !=======================================================================
     subroutine read_fnml(file)
-    !----------------------------------------------------------------------- 
-    !*DESCRIPTION: 
+    !-----------------------------------------------------------------------
+    !*DESCRIPTION:
     !   Read matrix of pre-integrated functions, Eq. (13)
     !   [Park, Phys. Rev. Let 2009]
     !
@@ -924,7 +924,7 @@ module inputs
         character(*) :: file
         ! declare variables
         integer :: nfk,nft,in_unit
-  
+
         if(verbose) print *, "Reading F^-1/2_mnl from file:"
         if(verbose) print *, "  ",trim(file)
         in_unit = get_free_file_unit(-1)
@@ -939,11 +939,11 @@ module inputs
         return
       end subroutine read_fnml
 
-      
+
     !=======================================================================
     subroutine read_gpec_peq(file,write_log)
-    !----------------------------------------------------------------------- 
-    !*DESCRIPTION: 
+    !-----------------------------------------------------------------------
+    !*DESCRIPTION:
     !   Read pmodb and divxprp fourier components (psi,m) from input file.
     !   Holdover from PENT - used to test development.
     !
@@ -955,12 +955,12 @@ module inputs
         ! declare arguments
         logical :: write_log
         character(*), intent(in) :: file
-        ! declare variables            
+        ! declare variables
         complex(r8), dimension(mstep,mpert) :: lagbpar,divxprp
         integer :: i,ms,mp,iout,istep,in_unit,out_unit
         type(cspline_type) :: outspl
-    
-          
+
+
         if(verbose) print *, "Reading pmodb and divxprp input file: "
         if(verbose) print *, '  ',trim(file)
         in_unit = get_free_file_unit(-1)
@@ -972,7 +972,7 @@ module inputs
         read(in_unit)lagbpar
         read(in_unit)divxprp
         close(in_unit)
-        
+
         ! form splines
         call cspline_alloc(dbob_m,mstep-1,mpert)
         call cspline_alloc(divx_m,mstep-1,mpert)
@@ -982,7 +982,7 @@ module inputs
         divx_m%fs(0:,:) = divxprp(:,:)
         call cspline_fit(dbob_m,"extrap")
         call cspline_fit(divx_m,"extrap")
-        
+
         ! write log - designed as check of reading routines
         if(write_log)then
             out_unit = get_free_file_unit(-1)
@@ -1012,5 +1012,5 @@ module inputs
         endif
     end subroutine read_gpec_peq
 
-    
+
 end module inputs


### PR DESCRIPTION
## Summary
- Remove trailing spaces on comment and blank lines in pentrc/inputs.f90 and pentrc/dcon_interface.f
- No functional changes

## Test plan
- [ ] Verify compilation unchanged