### PR TITLE
Add W_v output eigenvalues fix

### DIFF
--- a/dcon/dcon_netcdf.f
+++ b/dcon/dcon_netcdf.f
@@ -52,7 +52,8 @@ c     declarations.
 c-----------------------------------------------------------------------
       SUBROUTINE dcon_netcdf_out(wp,wv,wt,wt0,ep,ev,et)
 
-      COMPLEX(r8), DIMENSION(mpert), INTENT(IN) :: ep,ev,et
+      COMPLEX(r8), DIMENSION(mpert), INTENT(IN) :: ep,et
+      REAL(r8), DIMENSION(mpert), INTENT(IN) :: ev
       COMPLEX(r8), DIMENSION(mpert,mpert), INTENT(IN) :: wp,wv,wt,wt0
 
       INTEGER :: i, ncid,
@@ -182,7 +183,7 @@ c-----------------------------------------------------------------------
       CALL check( nf90_def_var(ncid, "W_v_eigenvector", nf90_double,
      $    (/m_dim, mo_dim, i_dim/), wv_id) )
       CALL check( nf90_def_var(ncid, "W_v_eigenvalue", nf90_double,
-     $    (/mo_dim, i_dim/), wvv_id) )
+     $    (/mo_dim/), wvv_id) )
       CALL check( nf90_put_att(ncid,wv_id,"long_name",
      $    "Vacuum Energy Eigenmodes") )
       CALL check( nf90_put_att(ncid,wvv_id,"long_name",
@@ -248,8 +249,7 @@ c-----------------------------------------------------------------------
      $             AIMAG(ep)/),(/mpert,2/))) )
       CALL check( nf90_put_var(ncid,wv_id,RESHAPE((/REAL(wv),
      $             AIMAG(wv)/),(/mpert,mpert,2/))) )
-      CALL check( nf90_put_var(ncid,wvv_id,RESHAPE((/REAL(ev),
-     $             AIMAG(ev)/),(/mpert,2/))) )
+      CALL check( nf90_put_var(ncid,wvv_id,ev) )
       CALL check( nf90_put_var(ncid,wt_id,RESHAPE((/REAL(wt),
      $             AIMAG(wt)/),(/mpert,mpert,2/))) )
       CALL check( nf90_put_var(ncid,wtv_id,RESHAPE((/REAL(et),

--- a/dcon/free.f
+++ b/dcon/free.f
@@ -60,7 +60,8 @@ c-----------------------------------------------------------------------
       REAL(r8) :: v1
       REAL(r8), DIMENSION(mpert) :: singfac
       ! eigenvalues are complex for gpec
-      COMPLEX(r8), DIMENSION(mpert) :: ep,ev,et,tt
+      COMPLEX(r8), DIMENSION(mpert) :: ep,et,tt
+      REAL(r8), DIMENSION(mpert) :: ev
 
       REAL(r8), DIMENSION(3*mpert-2) :: rwork
       REAL(r8), DIMENSION(2*mpert) :: rwork2

--- a/gpec/idcon.f
+++ b/gpec/idcon.f
@@ -524,7 +524,7 @@ c-----------------------------------------------------------------------
       RETURN
       END SUBROUTINE idcon_build
 c-----------------------------------------------------------------------
-c     subprogram 4. idcon_matric.
+c     subprogram 4. idcon_metric.
 c     reconstructs metric tensors from dcon.
 c-----------------------------------------------------------------------
       SUBROUTINE idcon_metric


### PR DESCRIPTION
Potential Bug find and Fix.

Comparisons between W_t and reconstructed matrix from eigen values and vectors was not working.

Matrix reconstruction tests were done with this script. (both before and after changes are included in comments of script)
[dcon_W_reconstruction_test.py](https://github.com/user-attachments/files/26952645/dcon_W_reconstruction_test.py)

The changes to dcon/free.f and dcon/dcon_netcdf.f now reflect that 'ev' is defined as explicitly real eigenvalues.

This can be seen from the call to zheev line305, ev needs to be real [zheev doc](https://www.netlib.org/lapack/explore-html/d8/d1c/group__heev_gadbb2b87ce42e51fdaac3228a857a58c8.html)