### PR TITLE
SLAYER: fix NaN Phi_res_crit — resolve under-sampled torque-balance nose

### DIFF
--- a/slayer/gslayer.f
+++ b/slayer/gslayer.f
@@ -37,7 +37,11 @@ c-----------------------------------------------------------------------
       REAL(r8) :: mrs,nrs,rho,b_l,v_a,Qconv,Q0,delta_n_p,
      $            lbeta,tau_i,tau_h,tau_r,tau_v
       REAL(r8) :: inQ_min,inQ_max,Q_sol,maxbal
-      
+      INTEGER :: ipass
+      INTEGER, PARAMETER :: nref=4
+      REAL(r8) :: xpk,rlo,rhi,rdq,rdqc,xq,bloc,jloc
+      COMPLEX(r8) :: dloc
+
       REAL(r8), DIMENSION(:), ALLOCATABLE :: inQs,iinQs,jxbl,bal
       COMPLEX(r8), DIMENSION(:), ALLOCATABLE :: deltal
       CHARACTER(3) :: sn,sm
@@ -157,18 +161,42 @@ c-----------------------------------------------------------------------
          CLOSE(out_unit)
       ENDIF
 
-      ! Identify the threshold from the maximum of the balance
-      ! parameter. Exclude non-finite entries (NaN from 0/0 or Inf
-      ! from a near-zero jxbl at a sign crossing) so they cannot
-      ! corrupt the location or value of the maximum.
+      ! The coarse scan above gives the overall torque-balance shape
+      ! and the diagnostic output. The locking "nose" (the maximum of
+      ! bal) can be a very narrow spike near inQ=Q0, however, and the
+      ! coarse grid can step right over it, leaving a spuriously
+      ! negative MAXVAL(bal) and hence a NaN br_th. Bracket the coarse
+      ! maximum and iteratively refine the scan around the running peak
+      ! so the nose is resolved regardless of how narrow it is. Exclude
+      ! non-finite entries (NaN from 0/0, Inf from a near-zero jxbl).
       index=MAXLOC(bal,MASK=(bal==bal .AND. ABS(bal)<HUGE(bal)))
-      Q_sol=inQs(index(1))
-      omega_sol=inQs(index(1))/Qconv
-      maxbal=MAXVAL(bal,MASK=(bal==bal .AND. ABS(bal)<HUGE(bal)))
-      ! The torque-balance maximum can fall at or below zero for outer
-      ! surfaces with a weak locking nose; sqrt of a negative argument
-      ! would return NaN and poison b_crit/Phi_res_crit downstream.
-      ! Floor at zero (no finite penetration threshold) and warn.
+      rdqc=(inQ_max-inQ_min)/inum
+      xpk=inQs(index(1))
+      rlo=xpk-2.0*rdqc
+      rhi=xpk+2.0*rdqc
+      maxbal=-HUGE(maxbal)
+      DO ipass=1,nref
+         rdq=(rhi-rlo)/inum
+         DO i=0,inum
+            xq=rlo+REAL(i)*rdq
+            dloc=riccati(xq,inQ_e,inQ_i,inpr,
+     $           inc_beta,inds,intau,inpe)
+            jloc=-AIMAG(1.0/(dloc+delta_n_p))
+            bloc=2.0*inpr*(Q0-xq)/jloc
+            IF (bloc==bloc .AND. ABS(bloc)<HUGE(bloc)
+     $           .AND. bloc>maxbal) THEN
+               maxbal=bloc
+               xpk=xq
+            ENDIF
+         ENDDO
+         rlo=xpk-2.0*rdq
+         rhi=xpk+2.0*rdq
+      ENDDO
+      Q_sol=xpk
+      omega_sol=xpk/Qconv
+      ! If even the refined nose is non-positive the surface has no
+      ! finite penetration threshold; floor at zero and warn rather
+      ! than propagating a NaN into b_crit/Phi_res_crit downstream.
       IF (maxbal>0.0_r8) THEN
          br_th=sqrt(maxbal/lu*(sval**2.0/2.0))
       ELSE

--- a/slayer/gslayer.f
+++ b/slayer/gslayer.f
@@ -36,7 +36,7 @@ c-----------------------------------------------------------------------
       REAL(r8) :: inQ,inQ_e,inQ_i,inpe,inc_beta,inds,intau,inlu
       REAL(r8) :: mrs,nrs,rho,b_l,v_a,Qconv,Q0,delta_n_p,
      $            lbeta,tau_i,tau_h,tau_r,tau_v
-      REAL(r8) :: inQ_min,inQ_max,Q_sol
+      REAL(r8) :: inQ_min,inQ_max,Q_sol,maxbal
       
       REAL(r8), DIMENSION(:), ALLOCATABLE :: inQs,iinQs,jxbl,bal
       COMPLEX(r8), DIMENSION(:), ALLOCATABLE :: deltal
@@ -157,11 +157,26 @@ c-----------------------------------------------------------------------
          CLOSE(out_unit)
       ENDIF
 
-      ! Identify the threshold from the maximum of the balance parameter
-      index=MAXLOC(bal,MASK=bal==bal)
+      ! Identify the threshold from the maximum of the balance
+      ! parameter. Exclude non-finite entries (NaN from 0/0 or Inf
+      ! from a near-zero jxbl at a sign crossing) so they cannot
+      ! corrupt the location or value of the maximum.
+      index=MAXLOC(bal,MASK=(bal==bal .AND. ABS(bal)<HUGE(bal)))
       Q_sol=inQs(index(1))
       omega_sol=inQs(index(1))/Qconv
-      br_th=sqrt(MAXVAL(bal,MASK=bal==bal)/lu*(sval**2.0/2.0))
+      maxbal=MAXVAL(bal,MASK=(bal==bal .AND. ABS(bal)<HUGE(bal)))
+      ! The torque-balance maximum can fall at or below zero for outer
+      ! surfaces with a weak locking nose; sqrt of a negative argument
+      ! would return NaN and poison b_crit/Phi_res_crit downstream.
+      ! Floor at zero (no finite penetration threshold) and warn.
+      IF (maxbal>0.0_r8) THEN
+         br_th=sqrt(maxbal/lu*(sval**2.0/2.0))
+      ELSE
+         br_th=0.0_r8
+         WRITE(*,'(1x,a,i0,a,i0,a)')
+     $      "!! WARNING: SLAYER torque balance has no positive "//
+     $      "maximum at m=",mms,", n=",nns,"; br_th set to 0"
+      ENDIF
       DEALLOCATE(inQs,deltal,jxbl,bal)
 
       RETURN


### PR DESCRIPTION
## Problem
On the omega DIII-D 176857 kinetic case, `gpec_slayer` produced `br_th = NaN` for the outer rational surfaces (q=5, 7, 8), which poisoned `b_crit` / `Phi_res_crit` in the GPEC outputs. The run finished with "Normal termination" — bad numbers, not a crash.

## Root cause (corrected after investigation)
`br_th = sqrt(MAXVAL(bal)/lu·sval²/2)`, where the threshold is the maximum of the torque-balance curve `bal(inQ) = 2·inpr·(Q0−inQ)/jxbl`. By construction `bal` crosses zero at `inQ = Q0` and the relevant "nose" (its maximum) is a **narrow positive spike** sitting just below `Q0`.

The bug is **under-resolution**, not a vanishing nose: the spike width shrinks for outer surfaces (q=5 ≈ 0.05, q=7 ≈ 0.009, q=8 ≈ 0.003) — far below the fixed coarse scan step `ΔinQ = 20/200 = 0.1`. The coarse grid stepped over the spike onto its negative shoulders, so `MAXVAL(bal)` came out negative and `sqrt()` returned NaN.

Verified by calling `riccati()` directly with the run's exact normalized layer parameters at increasing resolution:

| q | coarse (inum=200) | refined | true (inum≈13000) |
|---|---|---|---|
| 3 (control) | +52.40 | +52.60 | +52.58 (broad nose, already fine) |
| 5 | −0.231 → **NaN** | **+0.122** | +0.118 |
| 7 | −0.078 → **NaN** | **+0.0108** | +0.0103 |
| 8 | −0.077 → **NaN** | **+0.0039** | +0.0030 |

(Earlier "floor to zero" reasoning was wrong — these surfaces have a genuine, non-negligible threshold; q=5's would have been zeroed incorrectly.)

## Fix
Uniform refinement is impractical (q=8 would need `inum > 13000`). Instead:
1. Keep the cheap coarse global scan (overall shape + diagnostic `gpec_slayer_torque_balance_*.out` file).
2. **Iterative local refinement:** bracket the coarse maximum and re-scan ±2 cells around the running peak for `nref=4` passes. This resolves the nose regardless of width (~5× `riccati` calls/surface; total still small vs the run). `Q_sol`/`omega_sol` now come from the refined peak.
3. Retain the `max(bal) ≤ 0` floor (`br_th = 0` + warning) **only** as a final safety net for a genuinely absent nose; exclude non-finite `bal` entries (NaN/Inf) from the max.

## Alternatives investigated and ruled out
- **Extending the inQ scan range** — `bal(inQ)` plateaus deeply negative at `inQ = ±10`; the global max is the central nose, so a wider scan can't help.
- **Complex `delta_n_p = (1e-2, 1e-2)`** — recomputed from the logged `delta`; leaves `max(bal)` negative for all failing surfaces. `delta_n_p` left unchanged.

## Testing
- Builds clean with the production toolchain (gfortran-15, `-fallow-argument-mismatch`); `libslayer.a` and `bin/gpec` link.
- Algorithm validated against the run's exact parameters via a standalone `riccati()` driver (table above); the implemented coarse→bracket→refine variant reproduces the brute-force converged maxima for all surfaces.

Diagnostic figures (nose under-sampling, max(bal) vs resolution, ruled-out alternatives) available to attach.