### PR TITLE
Correct q sign-convention docs and enforce positive q (replaces #268)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ decomposition exp(im*theta - in*phi). A comprehensive reference is in
 - **helicity** = ipd * btd (+1 = RH, -1 = LH), computed in `gpec_main` (`gpec/gpec.f`)
 - **nn** (toroidal mode number) is always positive; resonant **m** is always positive
 - **F = R*Bt** is forced positive via ABS() in `read_eq_efit` (`equil/read_eq.f`)
-- **q** is recomputed by field-line integration in `direct_run` (`equil/direct.f`); the g-file q profile is unused, and q is always positive for g-file input
+- **q** is recomputed by field-line integration (`direct_run` in `equil/direct.f`; `inverse_run` in `equil/inverse.f` for inverse formats); the input file's q profile is unused, and the recomputed q is always positive
 - **omega_E** is positive for rotation in the direction of the toroidal coordinate zeta
 - The code does NOT use the COCOS standard
 - For SURFMN interface: `m_surfmn = helicity * m_gpec`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ decomposition exp(im*theta - in*phi). A comprehensive reference is in
 - **helicity** = ipd * btd (+1 = RH, -1 = LH), computed in `gpec_main` (`gpec/gpec.f`)
 - **nn** (toroidal mode number) is always positive; resonant **m** is always positive
 - **F = R*Bt** is forced positive via ABS() in `read_eq_efit` (`equil/read_eq.f`)
-- **q** is NOT forced positive (read directly from EFIT)
+- **q** is recomputed by field-line integration in `direct_run` (`equil/direct.f`); the g-file q profile is unused, and q is always positive for g-file input (negative `newq0` is the only override)
 - **omega_E** is positive for rotation in the direction of the toroidal coordinate zeta
 - The code does NOT use the COCOS standard
 - For SURFMN interface: `m_surfmn = helicity * m_gpec`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,7 @@ decomposition exp(im*theta - in*phi). A comprehensive reference is in
 - **helicity** = ipd * btd (+1 = RH, -1 = LH), computed in `gpec_main` (`gpec/gpec.f`)
 - **nn** (toroidal mode number) is always positive; resonant **m** is always positive
 - **F = R*Bt** is forced positive via ABS() in `read_eq_efit` (`equil/read_eq.f`)
-- **q** is recomputed by field-line integration in `direct_run` (`equil/direct.f`); the g-file q profile is unused, and q is always positive for g-file input (negative `newq0` is the only override)
+- **q** is recomputed by field-line integration in `direct_run` (`equil/direct.f`); the g-file q profile is unused, and q is always positive for g-file input
 - **omega_E** is positive for rotation in the direction of the toroidal coordinate zeta
 - The code does NOT use the COCOS standard
 - For SURFMN interface: `m_surfmn = helicity * m_gpec`

--- a/docs/sign_conventions.rst
+++ b/docs/sign_conventions.rst
@@ -130,8 +130,13 @@ Safety Factor :math:`q`
   for any combination of signs in the g-file. Reversing all signed
   quantities in a g-file (:math:`\psi`, ``simag``, ``sibry``, ``cpasma``,
   q) reproduces the original DCON results bit for bit.
-- Inverse equilibria (e.g. CHEASE) keep the q profile of the input file,
-  including its sign (``inverse_run`` in ``equil/inverse.f``).
+- **Inverse equilibria recompute q too.** The main inverse path
+  (``inverse_run`` in ``equil/inverse.f``, used by the CHEASE, JSOLVER,
+  TRANSP, and analytic formats) rebuilds q on each surface by a flux-surface
+  integration, exactly as the direct path does; the input file's q profile
+  is read into ``sq_in`` but not used, and the recomputed q is positive. The
+  one exception is the ``chease4`` format (``inverse_chease4_run``), which
+  takes q directly from the input file.
 
 
 Mode Numbers :math:`m` and :math:`n`
@@ -162,8 +167,8 @@ Why Positive :math:`m` Is Always Resonant
 
 Resonant surfaces are found by ``sing_find`` in ``dcon/sing.f``.
 It performs a binary search for flux surfaces where :math:`m = n \cdot q`.
-Since :math:`n > 0` (by convention) and :math:`q > 0` (guaranteed for
-direct equilibria, see the safety factor section above):
+Since :math:`n > 0` (by convention) and :math:`q > 0` (the recomputed q is
+always positive, see the safety factor section above):
 
 .. math::
 
@@ -295,7 +300,9 @@ For g-file input the sign part of the COCOS choice cannot matter:
 :math:`F > 0`, and discards the file's q profile, so g-files that differ
 only in sign conventions produce identical results. Field and current
 directions enter solely through ``ip_direction`` and ``bt_direction`` in
-``coil.in``. What does matter is the flux normalization: GPEC assumes the
+``coil.in``. The main inverse path likewise recomputes q rather than
+inheriting it from the input file. What does matter is the flux
+normalization: GPEC assumes the
 g-eqdsk standard of poloidal flux per radian (Wb/rad). A file carrying the
 full flux (the COCOS 11-18 family) yields a wrong q magnitude. Reports
 that g-files must be supplied in one specific COCOS trace to this unit
@@ -326,7 +333,7 @@ Quick Reference
      - Yes, ABS()
    * - :math:`q` (safety factor)
      - Recomputed by field-line integration
-     - Yes, positive for g-files
+     - Always positive
    * - :math:`n` (toroidal mode)
      - Always positive
      - By convention
@@ -348,7 +355,7 @@ Source Code References
 - **F = R*Bt forced positive**: ``read_eq_efit`` in ``equil/read_eq.f``
 - **q definition**: ``dcon/README``
 - **q from field-line integration**: ``direct_run`` in ``equil/direct.f``
-- **q copied from inverse input**: ``inverse_run`` in ``equil/inverse.f``
+- **q recomputed (inverse path)**: ``inverse_run`` in ``equil/inverse.f``
 - **Helicity computation**: ``gpec_main`` program in ``gpec/gpec.f``
 - **ip/bt direction**: ``input/coil.in``
 - **Poloidal mode range**: ``dcon`` program in ``dcon/dcon.F``

--- a/docs/sign_conventions.rst
+++ b/docs/sign_conventions.rst
@@ -132,10 +132,6 @@ Safety Factor :math:`q`
   q) reproduces the original DCON results bit for bit.
 - Inverse equilibria (e.g. CHEASE) keep the q profile of the input file,
   including its sign (``inverse_run`` in ``equil/inverse.f``).
-- ``newq0`` in ``equil.in`` rescales :math:`F` to set q on axis while
-  preserving the Grad-Shafranov solution (``direct_run`` in
-  ``equil/direct.f``). A negative ``newq0`` is the one way to impose
-  q < 0 on a direct equilibrium.
 
 
 Mode Numbers :math:`m` and :math:`n`

--- a/docs/sign_conventions.rst
+++ b/docs/sign_conventions.rst
@@ -96,9 +96,9 @@ Helicity is computed in the ``gpec_main`` program (``gpec/gpec.f``):
 
 - ``ip_direction`` and ``bt_direction`` are set in ``coil.in``.
   "positive" means CCW viewed from above; "negative" means CW.
-- **helicity = +1**: right-handed (RH) --- :math:`B_t` and :math:`I_p` in the
+- **helicity = +1**: right-handed (RH), :math:`B_t` and :math:`I_p` in the
   same direction.
-- **helicity = -1**: left-handed (LH) --- :math:`B_t` and :math:`I_p` opposed.
+- **helicity = -1**: left-handed (LH), :math:`B_t` and :math:`I_p` opposed.
 - The helicity value is stored in the ``gpec_control_output`` netcdf file.
 
 
@@ -121,12 +121,21 @@ Safety Factor :math:`q`
 ========================
 
 - Defined as :math:`q = (\mathbf{B} \cdot \nabla\zeta) / (\mathbf{B} \cdot \nabla\theta)`.
-- **Not forced positive.** Read directly from the EFIT g-file without sign
-  manipulation (unlike :math:`F`).
-- In standard tokamak operation, EFIT provides :math:`q > 0`.
-- Can be adjusted via ``newq0`` in ``equil.in``, which modifies :math:`F`
-  to match while preserving the Grad-Shafranov solution
-  (``direct_run`` in ``equil/direct.f``).
+- **Recomputed, not read.** For direct equilibria (EFIT g-files), the q
+  profile in the file is read but never used. ``direct_run`` in
+  ``equil/direct.f`` rebuilds q on each flux surface from a field-line
+  integration.
+- **Always positive for g-file input.** The integration uses the
+  sign-normalized :math:`\psi` map and :math:`|F|`, so q comes out positive
+  for any combination of signs in the g-file. Reversing all signed
+  quantities in a g-file (:math:`\psi`, ``simag``, ``sibry``, ``cpasma``,
+  q) reproduces the original DCON results bit for bit.
+- Inverse equilibria (e.g. CHEASE) keep the q profile of the input file,
+  including its sign (``inverse_run`` in ``equil/inverse.f``).
+- ``newq0`` in ``equil.in`` rescales :math:`F` to set q on axis while
+  preserving the Grad-Shafranov solution (``direct_run`` in
+  ``equil/direct.f``). A negative ``newq0`` is the one way to impose
+  q < 0 on a direct equilibrium.
 
 
 Mode Numbers :math:`m` and :math:`n`
@@ -157,7 +166,8 @@ Why Positive :math:`m` Is Always Resonant
 
 Resonant surfaces are found by ``sing_find`` in ``dcon/sing.f``.
 It performs a binary search for flux surfaces where :math:`m = n \cdot q`.
-Since :math:`n > 0` (by convention) and :math:`q > 0` (standard tokamak):
+Since :math:`n > 0` (by convention) and :math:`q > 0` (guaranteed for
+direct equilibria, see the safety factor section above):
 
 .. math::
 
@@ -284,6 +294,17 @@ system. The conventions described in this document are GPEC-native and predate
 COCOS. Users interfacing with COCOS-aware codes must manually translate between
 conventions.
 
+For g-file input the sign part of the COCOS choice cannot matter:
+``read_eq_efit`` sign-normalizes the :math:`\psi` map, forces
+:math:`F > 0`, and discards the file's q profile, so g-files that differ
+only in sign conventions produce identical results. Field and current
+directions enter solely through ``ip_direction`` and ``bt_direction`` in
+``coil.in``. What does matter is the flux normalization: GPEC assumes the
+g-eqdsk standard of poloidal flux per radian (Wb/rad). A file carrying the
+full flux (the COCOS 11-18 family) yields a wrong q magnitude. Reports
+that g-files must be supplied in one specific COCOS trace to this unit
+requirement, since the sign choices are normalized away on read.
+
 
 Quick Reference
 ===============
@@ -308,8 +329,8 @@ Quick Reference
      - Always positive
      - Yes, ABS()
    * - :math:`q` (safety factor)
-     - From EFIT, typically positive
-     - No
+     - Recomputed by field-line integration
+     - Yes, positive for g-files
    * - :math:`n` (toroidal mode)
      - Always positive
      - By convention
@@ -330,6 +351,8 @@ Source Code References
 - **Poloidal flux sign**: ``read_eq_efit`` in ``equil/read_eq.f``
 - **F = R*Bt forced positive**: ``read_eq_efit`` in ``equil/read_eq.f``
 - **q definition**: ``dcon/README``
+- **q from field-line integration**: ``direct_run`` in ``equil/direct.f``
+- **q copied from inverse input**: ``inverse_run`` in ``equil/inverse.f``
 - **Helicity computation**: ``gpec_main`` program in ``gpec/gpec.f``
 - **ip/bt direction**: ``input/coil.in``
 - **Poloidal mode range**: ``dcon`` program in ``dcon/dcon.F``

--- a/equil/direct.f
+++ b/equil/direct.f
@@ -195,7 +195,6 @@ c-----------------------------------------------------------------------
       sq%name="  sq  "
       sq%title=(/" psi  ","  f   ","  p   ","  q   "/)
       q0=sq%fs(0,4)-sq%fs1(0,4)*sq%xs(0)
-      IF(newq0 == -1)newq0=-q0
 c-----------------------------------------------------------------------
 c     revise q profile.
 c-----------------------------------------------------------------------
@@ -204,7 +203,7 @@ c-----------------------------------------------------------------------
          f0fac=f0**2*((newq0/q0)**2-1)
          q0=newq0
          DO ipsi=0,mpsi
-            ffac=SQRT(1+f0fac/sq%fs(ipsi,1)**2)*SIGN(one,newq0)
+            ffac=SQRT(1+f0fac/sq%fs(ipsi,1)**2)
             sq%fs(ipsi,1)=sq%fs(ipsi,1)*ffac
             sq%fs(ipsi,4)=sq%fs(ipsi,4)*ffac
             rzphi%fs(ipsi,:,3)=rzphi%fs(ipsi,:,3)*ffac

--- a/equil/equil.f
+++ b/equil/equil.f
@@ -55,6 +55,11 @@ c-----------------------------------------------------------------------
          READ(UNIT=in_unit,NML=equil_output)
       ENDIF
       CALL ascii_close(in_unit)
+c-----------------------------------------------------------------------
+c     guard against negative newq0 (negative q is not supported).
+c-----------------------------------------------------------------------
+      IF(newq0 < 0)CALL program_stop("newq0 < 0 is not supported: "//
+     $     "q must be positive. Use newq0 = 0 (default) or newq0 > 0.")
       IF(PRESENT(op_psihigh))THEN
          psihigh = op_psihigh
          IF(verbose) WRITE(*,*) "Reforming equilibrium with new psihigh"

--- a/equil/inverse.f
+++ b/equil/inverse.f
@@ -237,7 +237,6 @@ c-----------------------------------------------------------------------
       ENDDO
       CALL spline_fit(sq,"extrap")
       q0=sq%fs(0,4)-sq%fs1(0,4)*sq%xs(0)
-      IF(newq0 == -1)newq0=-q0
 c-----------------------------------------------------------------------
 c     revise q profile.
 c-----------------------------------------------------------------------
@@ -246,7 +245,7 @@ c-----------------------------------------------------------------------
          f0fac=f0**2*((newq0/q0)**2-one)
          q0=newq0
          DO ipsi=0,mpsi
-            ffac=SQRT(1+f0fac/sq%fs(ipsi,1)**2)*SIGN(one,newq0)
+            ffac=SQRT(1+f0fac/sq%fs(ipsi,1)**2)
             sq%fs(ipsi,1)=sq%fs(ipsi,1)*ffac
             sq%fs(ipsi,4)=sq%fs(ipsi,4)*ffac
             rzphi%fs(ipsi,:,3)=rzphi%fs(ipsi,:,3)*ffac
@@ -579,7 +578,11 @@ c-----------------------------------------------------------------------
       ENDDO
       CALL spline_fit(sq,"extrap")
       q0=sq%fs(0,4)-sq%fs1(0,4)*sq%xs(0)
-      IF(newq0 == -1)newq0=-q0
+c-----------------------------------------------------------------------
+c     enforce positive q (chease4 takes q directly from the input file).
+c-----------------------------------------------------------------------
+      IF(MINVAL(sq%fs(:,4)) <= 0)CALL program_stop
+     $     ("chease4 input q must be positive (GPEC requires q > 0).")
 c-----------------------------------------------------------------------
 c     revise q profile.
 c-----------------------------------------------------------------------
@@ -588,7 +591,7 @@ c-----------------------------------------------------------------------
          f0fac=f0**2*((newq0/q0)**2-one)
          q0=newq0
          DO ipsi=0,mpsi
-            ffac=SQRT(1+f0fac/sq%fs(ipsi,1)**2)*SIGN(one,newq0)
+            ffac=SQRT(1+f0fac/sq%fs(ipsi,1)**2)
             sq%fs(ipsi,1)=sq%fs(ipsi,1)*ffac
             sq%fs(ipsi,4)=sq%fs(ipsi,4)*ffac
             rzphi%fs(ipsi,:,3)=rzphi%fs(ipsi,:,3)*ffac

--- a/equil/read_eq.f
+++ b/equil/read_eq.f
@@ -1498,13 +1498,12 @@ c-----------------------------------------------------------------------
 c-----------------------------------------------------------------------
 c     revise q profile.
 c-----------------------------------------------------------------------
-      IF(newq0 == -1)newq0=-q0
       IF(newq0 /= 0)THEN
          f0=sq%fs(0,1)-sq%fs1(0,1)*sq%xs(0)
          f0fac=f0**2*((newq0/q0)**2-one)
          q0=newq0
          DO ipsi=0,mpsi
-            ffac=SQRT(1+f0fac/sq%fs(ipsi,1)**2)*SIGN(one,newq0)
+            ffac=SQRT(1+f0fac/sq%fs(ipsi,1)**2)
             sq%fs(ipsi,1)=sq%fs(ipsi,1)*ffac
             sq%fs(ipsi,4)=sq%fs(ipsi,4)*ffac
             rzphi%fs(ipsi,:,3)=rzphi%fs(ipsi,:,3)*ffac


### PR DESCRIPTION
**This PR replaces #268** (which is from a fork the maintainers cannot push to). It contains all of #268's commits plus follow-up corrections from review. Once this is open, #268 can be closed.

## Background

#268 set out to correct the safety-factor `q` statements in the sign-conventions reference. Review surfaced a factual error in #268's own text and a related code-hardening opportunity, addressed here.

## Documentation (`docs/sign_conventions.rst`, `CLAUDE.md`)

- **Corrected the inverse-equilibrium claim.** #268 stated inverse equilibria "keep the q profile of the input file, including its sign." In fact the main inverse path (`inverse_run`, `equil/inverse.f`) recomputes q on each surface by flux-surface integration, exactly like `direct_run` — the input file's q profile is read into `sq_in` but unused. The text now reflects this.
- **Noted the one exception:** the `chease4` format (`inverse_chease4_run`) takes q directly from the input file.
- Removed all "negative `newq0`" wording — q is documented simply as always positive (this is not standard usage and shouldn't be advertised to new users).

## Code — enforce positive q (`equil/`)

GPEC requires positive q (positive `nn`, positive resonant `m`; the mode-range and convention machinery assume `q > 0`). Negative q was only reachable via undocumented, unvetted paths, now closed:

- **`equil.f`:** guard rejecting `newq0 < 0` (the only knob that could force q negative), placed right after the namelist read.
- **`inverse.f` (`inverse_chease4_run`):** positive-q guard `IF(MINVAL(sq%fs(:,4)) <= 0)` for chease4 files whose q column is itself negative.
- **`direct.f`, `inverse.f` (×2), `read_eq.f`:** removed the now-unreachable `IF(newq0==-1)newq0=-q0` sentinel and `*SIGN(one,newq0)` sign-flip factor. If field/q reversal is ever wanted, it should be a clearly-named flag, not a magic negative `newq0`.

## Verification

- Full build succeeds (gfortran); all modified fixed-format `.f` lines ≤72 chars.
- DCON on the solovev inverse-path example: `newq0=-1` → rejected with a clear message; `newq0=0` → q0=1.900; `newq0=2.0` → q0=2.000, **bit-identical** to before the cruft removal (the removed `SIGN(one,newq0)` was `+1` for valid positive `newq0`).
- `docs/sign_conventions.rst` parses under docutils (only the pre-existing Sphinx-only `:doc:` role message remains).
- The chease4 guard compiles but is not runtime-tested (no chease4 input file in-repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)