### PR TITLE
PENTRC: fix OpenMP data race on the energy contour flag (and a nested-quadrature tolerance defect)

### DIFF
--- a/pentrc/energy.f90
+++ b/pentrc/energy.f90
@@ -69,7 +69,15 @@ module energy_integration
             energy_wb,&
             energy_nuk,&
             energy_leff
-    !$omp threadprivate(energy_wn,energy_wt,energy_we,energy_wd,energy_wb,&
+    ! energy_imaxis selects the integration contour inside xintgrnd, and
+    ! xintgrl_lsode flips it between its imaginary-axis and real-axis legs.  It
+    ! is per-integration state exactly like the frequencies below it, so it must
+    ! be threadprivate too: shared, one thread's imaginary leg silently switches
+    ! another thread's integrand from x + i*ximag to i*x, turning exp(-cx) from
+    ! a decaying exponential into an oscillation and injecting values orders of
+    ! magnitude too large into the pitch integrand.
+    !$omp threadprivate(energy_imaxis,&
+    !$omp&              energy_wn,energy_wt,energy_we,energy_wd,energy_wb,&
     !$omp&              energy_nuk,energy_leff,energy_n)
 
     type record

--- a/pentrc/pentrc_interface.f90
+++ b/pentrc/pentrc_interface.f90
@@ -111,9 +111,15 @@ module pentrc_interface
         pentrc_threads = 0,&
         openmp_threads = 0
 
+    !> How much tighter the energy integration is than the pitch integration
+    !> when atol_x/rtol_x are left at their derive-me default.
+    real(r8), parameter :: nested_tolerance_margin = 1e-2
+
     real(r8) ::    &
         atol_xlmda=1e-6, &
         rtol_xlmda=1e-3, &
+        atol_x=-1, &
+        rtol_x=-1, &
         nfac=1.0,  &
         tfac=1.0,  &
         wefac=1.0, &
@@ -148,7 +154,8 @@ module pentrc_interface
             jac_in, jsurf_in, tmag_in, power_bin, power_bpin, power_rin, power_rcin
 
     namelist/pent_control/nfac, tfac, wefac, wdfac, wpfac, nufac, divxfac, &
-            atol_xlmda, rtol_xlmda, atol_psi, rtol_psi, nlmda, ntheta, ximag, xmax, psilims, &
+            atol_xlmda, rtol_xlmda, atol_x, rtol_x, atol_psi, rtol_psi, &
+            nlmda, ntheta, ximag, xmax, psilims, &
             use_classic_splines,pentrc_threads,openmp_threads,force_xialpha
 
     namelist/pent_output/moment, output_ascii, output_netcdf, &
@@ -221,8 +228,7 @@ module pentrc_interface
         !if(any(psilim/=0)) print *, "!! WARNING: psilim has been deprecated. Use psilims."
 
         ! distribute some simplified inputs to module circles
-        xatol = atol_xlmda
-        xrtol = rtol_xlmda
+        call set_nested_tolerances
         xnufac= nufac
         xnutype= nutype
         xf0type= f0type
@@ -279,8 +285,7 @@ module pentrc_interface
         close(i)
         
         ! distribute inputs to PENTRC module circles
-        xatol = atol_xlmda
-        xrtol = rtol_xlmda
+        call set_nested_tolerances
         xnufac= nufac
         xnutype= nutype
         xf0type= f0type 
@@ -307,6 +312,37 @@ module pentrc_interface
         
     end subroutine get_pentrc
     
+
+    !=======================================================================
+    subroutine set_nested_tolerances
+    !-----------------------------------------------------------------------
+    !*DESCRIPTION:
+    !   Give the energy integration its own, tighter tolerances.
+    !
+    !   The pitch integral's integrand IS the energy integral, so this is a
+    !   nested adaptive quadrature.  With one tolerance for both, the outer
+    !   integrator chases the inner one's quadrature error, which is not a
+    !   smooth function of lambda; LSODE then shrinks its step without bound
+    !   and stops with "too many steps in lambda required".
+    !
+    !   Negative atol_x/rtol_x, the default, means "derive from the pitch
+    !   tolerances".  A deck may set them explicitly, including back to the
+    !   old aliased values.
+    !-----------------------------------------------------------------------
+        implicit none
+        if(atol_x < 0) then
+            xatol = atol_xlmda * nested_tolerance_margin
+        else
+            xatol = atol_x
+        endif
+        if(rtol_x < 0) then
+            xrtol = rtol_xlmda * nested_tolerance_margin
+        else
+            xrtol = rtol_x
+        endif
+    end subroutine set_nested_tolerances
+
+
 end module pentrc_interface
     
 


### PR DESCRIPTION
PENTRC aborts with `lambdaintgrl_lsode - too many steps in lambda required` on an ITER equilibrium, independently of compiler, tolerances, `xmax`, `ximag`, `nl` and kinetic profiles. The root cause is a data race.

## The race

`energy_imaxis` selects the integration contour inside `xintgrnd`:

```fortran
if(energy_imaxis)then
   cx = xj*x            ! imaginary axis
else
   cx = x + xj*ximag    ! real axis, Landau offset
endif
```

`xintgrl_lsode` flips it between its imaginary-axis and real-axis legs (`energy.f90:190`, `:223`). It is per-integration state exactly like `energy_wn`, `energy_wd`, `energy_leff` and the rest — and it is the only one of them missing from the `threadprivate` list.

Shared, one thread's imaginary leg silently switches another thread's integrand from `x + i*ximag` to `i*x`. `exp(-cx)` stops decaying and starts oscillating, so values from deep in the Maxwellian tail return order `1e4` instead of `1e-2`. The pitch integrand is then not a function of `lambda` at all: in `pentrc_lambdaintrgl_lsode.err`, neighbouring `lambda` separated by `1e-8` differ by **130% on average**, spanning `-9.9e3` to `+1.4e4` around a median of `9e-3`. LSODE shrinks its step without bound and gives up.

This explains why the failure looked impossible to pin down: it does not depend on the numerics, it depends on the **thread count**. Decks that set the deprecated `openmp_threads` silently run on every available core.

### Scope of the `threadprivate` claim

For the ordinary parallel path the fix is complete: `energy_wn`, `energy_wt`, `energy_we`, `energy_wd`, `energy_wb`, `energy_nuk`, `energy_leff`, `energy_n` and now `energy_imaxis` are all thread-private (`energy.f90:62-81`), and LSODE's `/DLS002/` common block is thread-private too (`lsode2.f:29-30`).

It is **not** a claim that all of `energy.f90` is thread-safe. `xintgrl_lsode(..., op_record=.true.)` calls `record_method` (`energy.f90:293`), which mutates the shared `energy_record` object (`energy.f90:478-513`) without synchronisation. Production recording is serial today, so this does not affect the demonstrated fix, but the recorded path should not be parallelised as it stands.

## Evidence

Same deck, same binary, unmodified ITER case:

| | result |
|---|---|
| before | 1006 energy-integral failures, pitch integral aborts, no output |
| after, 1 thread | clean, writes `pentrc_tgar_n3.out` and `pentrc_pgar_n3.out` |
| after, 16 threads | clean, and **bit-identical** to the 1-thread result |

Bit-identical output across thread counts is the correctness gate for a race fix, and it holds on all 29 columns of both output files.

## Second commit: the nested quadrature shared one tolerance

`pentrc_interface.f90` aliased `xatol/xrtol` to the same `atol_xlmda/rtol_xlmda` pair used for the pitch integral. The pitch integrand *is* the energy integral, so the outer integrator was asked to resolve its integrand to `rtol_xlmda` while that integrand was itself computed only to `rtol_xlmda`, and it then chases the inner integrator's own quadrature error. The energy integration now takes its own `atol_x`/`rtol_x`.

**This changes default numerical behaviour, deliberately.** With `atol_x`/`rtol_x` left at their derive-me sentinel, the energy tolerances become `nested_tolerance_margin = 1e-2` times the pitch tolerances, so the shipped defaults move

| | energy `atol` | energy `rtol` |
|---|---|---|
| before (aliased to pitch) | `1e-6` | `1e-3` |
| after (derived, `1e-2` margin) | `1e-8` | `1e-5` |
| `energy.f90` module defaults, for reference | `1e-12` | `1e-9` |

Every deck that does not set the new controls therefore integrates the energy variable more tightly than before, and pays for it in runtime. That is the intent — the previous nesting was inconsistent — but it is a behaviour change, not a no-op, and reviewers should decide whether `1e-2` is the margin they want. Note the derived values do **not** restore `energy.f90`'s own `1e-12/1e-9`; a deck can ask for those explicitly with `atol_x`/`rtol_x`.

## Withdrawn from this PR

An earlier revision also removed the degenerate endpoints from the trapped-only pitch interval. That hunk is gone. The reasoning was wrong in general: `lmdamin = max(1/(1+epsr), bo/bmax)` and `lmdamax = min(1/(1-epsr), bo/bmin)` are degenerate only when the `bo/bmax` or `bo/bmin` term wins the extremum; when the cylindrical `epsr` bound wins, that endpoint can have two regular bounce points and deleting it discards nonsingular contributions. A correct fix has to test which term won. Filed separately rather than bundled here.

Built and tested with gfortran 15.
