### PR TITLE
PENTRC: omega_D in the GAR branch carries a spurious major radius

### DIFF
--- a/pentrc/energy.f90
+++ b/pentrc/energy.f90
@@ -69,7 +69,15 @@ module energy_integration
             energy_wb,&
             energy_nuk,&
             energy_leff
-    !$omp threadprivate(energy_wn,energy_wt,energy_we,energy_wd,energy_wb,&
+    ! energy_imaxis selects the integration contour inside xintgrnd, and
+    ! xintgrl_lsode flips it between its imaginary-axis and real-axis legs.  It
+    ! is per-integration state exactly like the frequencies below it, so it must
+    ! be threadprivate too: shared, one thread's imaginary leg silently switches
+    ! another thread's integrand from x + i*ximag to i*x, turning exp(-cx) from
+    ! a decaying exponential into an oscillation and injecting values orders of
+    ! magnitude too large into the pitch integrand.
+    !$omp threadprivate(energy_imaxis,&
+    !$omp&              energy_wn,energy_wt,energy_we,energy_wd,energy_wb,&
     !$omp&              energy_nuk,energy_leff,energy_n)
 
     type record

--- a/pentrc/pentrc_interface.f90
+++ b/pentrc/pentrc_interface.f90
@@ -111,9 +111,15 @@ module pentrc_interface
         pentrc_threads = 0,&
         openmp_threads = 0
 
+    !> How much tighter the energy integration is than the pitch integration
+    !> when atol_x/rtol_x are left at their derive-me default.
+    real(r8), parameter :: nested_tolerance_margin = 1e-2
+
     real(r8) ::    &
         atol_xlmda=1e-6, &
         rtol_xlmda=1e-3, &
+        atol_x=-1, &
+        rtol_x=-1, &
         nfac=1.0,  &
         tfac=1.0,  &
         wefac=1.0, &
@@ -148,7 +154,8 @@ module pentrc_interface
             jac_in, jsurf_in, tmag_in, power_bin, power_bpin, power_rin, power_rcin
 
     namelist/pent_control/nfac, tfac, wefac, wdfac, wpfac, nufac, divxfac, &
-            atol_xlmda, rtol_xlmda, atol_psi, rtol_psi, nlmda, ntheta, ximag, xmax, psilims, &
+            atol_xlmda, rtol_xlmda, atol_x, rtol_x, atol_psi, rtol_psi, &
+            nlmda, ntheta, ximag, xmax, psilims, &
             use_classic_splines,pentrc_threads,openmp_threads,force_xialpha
 
     namelist/pent_output/moment, output_ascii, output_netcdf, &
@@ -221,8 +228,7 @@ module pentrc_interface
         !if(any(psilim/=0)) print *, "!! WARNING: psilim has been deprecated. Use psilims."
 
         ! distribute some simplified inputs to module circles
-        xatol = atol_xlmda
-        xrtol = rtol_xlmda
+        call set_nested_tolerances
         xnufac= nufac
         xnutype= nutype
         xf0type= f0type
@@ -279,8 +285,7 @@ module pentrc_interface
         close(i)
         
         ! distribute inputs to PENTRC module circles
-        xatol = atol_xlmda
-        xrtol = rtol_xlmda
+        call set_nested_tolerances
         xnufac= nufac
         xnutype= nutype
         xf0type= f0type 
@@ -307,6 +312,37 @@ module pentrc_interface
         
     end subroutine get_pentrc
     
+
+    !=======================================================================
+    subroutine set_nested_tolerances
+    !-----------------------------------------------------------------------
+    !*DESCRIPTION:
+    !   Give the energy integration its own, tighter tolerances.
+    !
+    !   The pitch integral's integrand IS the energy integral, so this is a
+    !   nested adaptive quadrature.  With one tolerance for both, the outer
+    !   integrator chases the inner one's quadrature error, which is not a
+    !   smooth function of lambda; LSODE then shrinks its step without bound
+    !   and stops with "too many steps in lambda required".
+    !
+    !   Negative atol_x/rtol_x, the default, means "derive from the pitch
+    !   tolerances".  A deck may set them explicitly, including back to the
+    !   old aliased values.
+    !-----------------------------------------------------------------------
+        implicit none
+        if(atol_x < 0) then
+            xatol = atol_xlmda * nested_tolerance_margin
+        else
+            xatol = atol_x
+        endif
+        if(rtol_x < 0) then
+            xrtol = rtol_xlmda * nested_tolerance_margin
+        else
+            xrtol = rtol_x
+        endif
+    end subroutine set_nested_tolerances
+
+
 end module pentrc_interface
     
 

--- a/pentrc/torque.F90
+++ b/pentrc/torque.F90
@@ -738,7 +738,14 @@ module torque
                     ! Bounce averaged Lambda functions
                     fbnce%xs(ilmda-1) = lmda
                     wbbar = ro*twopi/((2-sigma)*bspl%fsi(bspl%mx,1))
-                    wdbar = ro*ro*bo*wdfac*wbbar*2*(2-sigma)*bspl%fsi(bspl%mx,2)
+                    ! wbbar is omega_b/bhat, so it carries one factor of ro that
+                    ! bhat takes back out. dhat removes only the explicit ro**2,
+                    ! so a third ro from wbbar would survive and leave omega_D a
+                    ! velocity rather than a frequency. Hence ro, not ro*ro:
+                    ! wdbar*dhat = 4 pi (T/chrg) I2/I1 = -(1/chrg)(dJ/dpsi)/tau_b,
+                    ! the canonical precession, with I1 in bspl%fsi(:,1) and I2
+                    ! in bspl%fsi(:,2) and d/dpsi taken against chi1.
+                    wdbar = ro*bo*wdfac*wbbar*2*(2-sigma)*bspl%fsi(bspl%mx,2)
                     bhat = sqrt(2*kin_f(s+2)/mass)/ro
                     dhat = (kin_f(s+2)/chrg)/(bo*ro*ro)
                     fbnce%fs(ilmda-1,1) = wbbar*bhat

--- a/pentrc/torque.F90
+++ b/pentrc/torque.F90
@@ -742,9 +742,14 @@ module torque
                     ! bhat takes back out. dhat removes only the explicit ro**2,
                     ! so a third ro from wbbar would survive and leave omega_D a
                     ! velocity rather than a frequency. Hence ro, not ro*ro:
-                    ! wdbar*dhat = 4 pi (T/chrg) I2/I1 = -(1/chrg)(dJ/dpsi)/tau_b,
+                    ! |wdbar*dhat| = 4 pi (T/chrg) |I2/I1| = |(1/chrg)(dJ/dpsi)/tau_b|,
                     ! the canonical precession, with I1 in bspl%fsi(:,1) and I2
-                    ! in bspl%fsi(:,2) and d/dpsi taken against chi1.
+                    ! in bspl%fsi(:,2) and d/dpsi taken against chi1. Magnitudes
+                    ! only: the familiar minus sign needs P_phi = +chrg*psi_p,
+                    ! and GPEC does not fix that convention here -- EFIT signs
+                    ! are normalised away in equil/read_eq.f and the toroidal
+                    ! angle carries a helicity declared in coil.in. This change
+                    ! multiplies by a positive number and alters no sign.
                     wdbar = ro*bo*wdfac*wbbar*2*(2-sigma)*bspl%fsi(bspl%mx,2)
                     bhat = sqrt(2*kin_f(s+2)/mass)/ro
                     dhat = (kin_f(s+2)/chrg)/(bo*ro*ro)


### PR DESCRIPTION
Stacked on #280 (`agent/pentrc-nested-quadrature-tolerances`); please read that one first, since the ITER case cannot run at all without it.

## What this changes

One factor on one line in `pentrc/torque.F90`, in the general-aspect-ratio bounce average:

```diff
-                    wdbar = ro*ro*bo*wdfac*wbbar*2*(2-sigma)*bspl%fsi(bspl%mx,2)
+                    wdbar = ro*bo*wdfac*wbbar*2*(2-sigma)*bspl%fsi(bspl%mx,2)
```

## Why

**The operator is correct and is not touched.** With `vpar = 1 - lmda*b/bo`, the second `bspl` integrand is *exactly* `d/dPsi` of the first's action companion at fixed `lmda`:

```
d/dPsi [ sqrt(vpar) J b ]
  = -lmda b (db/dPsi) J/(2 bo sqrt(vpar)) + sqrt(vpar)[ (dJ/dPsi) b + J db/dPsi ]
  = J (db/dPsi) (1 - 1.5 lmda b/bo)/sqrt(vpar) + (dJ/dPsi) b sqrt(vpar)
```

which is the line at `torque.F90:708`. So with `dl = J b dtheta` and `J_par = oint m v_par dl`, the bounce average is the canonical precession

```
|omega_phi| = |(1/chrg) (dJ_par/dpsi_p) / tau_b| = 4 pi (T/chrg) |I2/I1|
```

the `4 pi` because `chi1 = twopi*psio` makes the tabulated `eqfun_fx(1)/chi1` and `rzphi_fx(4)/chi1**2` derivatives with respect to the *full* poloidal flux, while the canonical momentum wants `psi_p = Psi_pol/(2 pi)`.

**The overall sign is a convention question and this PR does not settle it.** The familiar form `omega_phi = -(1/chrg)(dJ_par/dpsi_p)/tau_b` needs `P_phi = +chrg psi_p`; with `P_phi = -chrg psi_p` the sign reverses. GPEC cannot be read off as one or the other from here: EFIT input signs are normalised away in `equil/read_eq.f:666-680`, and the native toroidal coordinate is mapped to the laboratory angle with `phi = -helicity*(2 pi zeta + dphi)` in `coil/field.F:169-190`, with `helicity` *declared* in `coil.in` rather than derived from the equilibrium. So what is established below is the **magnitude**, and with it the removal of exactly one positive factor `ro`. The patch multiplies by a positive number and changes no sign; the sign question is tracked separately.

**The prefactor is not.** Substituting the code's own definitions,

```
wbbar = ro*twopi/((2-sigma)*I1)             bhat = sqrt(2T/mass)/ro
wdbar = ro*ro*bo*wdfac*wbbar*2*(2-sigma)*I2 dhat = (T/chrg)/(bo*ro*ro)

omega_b = wbbar*bhat = 2 pi/tau_b                      <- ro cancels, correct
omega_D = wdbar*dhat = 4 pi ro wdfac (T/chrg) I2/I1    <- one ro survives
```

`wbbar` is `omega_b/bhat`, so it carries a factor `ro` that `bhat` removes again. Reusing it inside `wdbar` imports that `ro` a third time, and `dhat` cancels only the two written explicitly.

**The surviving factor is a length, not a `2 pi`.** This matters because `ro = 6.411 m` and `2 pi = 6.283` are only 2% apart. `I1` is in metres since `J b dtheta = dl`; in `I2` every term carries the same `J*b` product divided by `Psi`, so `I2/I1` has units `1/Wb` *whatever* internal normalisation `b` and `J` carry — any constant rescaling of `J*b` cancels in the ratio. With `T/chrg` in volts and `V/Wb = 1/s`, the correct expression is already a frequency and `omega_D` as computed has units of m/s. No dimensionless constant can repair that.

## Verification

Against an independently validated canonical precession operator (checked against an integrated guiding-centre orbit) on the same equilibrium, read through a Boozer description rather than DCON's chart. Metric is the least-squares slope of `omega_D` against the reference over all pitches on a surface — a per-point ratio is ill conditioned where `omega_D` crosses zero.

| | median slope | range, 7 surfaces | predicted |
|---|---:|---|---:|
| before | `-6.494` | `-6.795` to `-6.087` | `-ro = -6.411` |
| after | `-1.021` | `-1.063` to `-0.965` | `-1.000` |

The minus signs in the predicted column are the *observed* relative orientation of the two operators carried across, not a derived one — see the convention caveat above. What the measurement establishes is that the ratio's magnitude goes from `ro` to `1`.

`omega_b`, built from the same `bspl%fsi(:,1)`, agrees to within `[0.9964, 1.0011]` both before and after. That is the control: it pins `I1` to SI metres, and with it the units of `I2/I1`, and it shows the change is confined to the precession prefactor.

Residual `1`–`2%` is the difference between the two equilibrium descriptions for this operator, independently measured at `0.6`–`5.3%`.

Supporting checks:

- **`chi1` is SI, not assumed to be.** Integrating `dpsi_pol/ds = |iota| Phi_edge/(2 pi)` over the Boozer file gives `psi_p(edge) = 11.8809 Wb` against DCON's `chi1/(2 pi) = 11.8828 Wb`, agreeing to `1.6e-4`. Had the `2 pi` sat elsewhere in the chain the prediction would have been `2 pi ro = 40.3`, which the measurement excludes.
- **Trapped domains match independently.** PENTRC reports `Lambda` in `[0.9064, 1.0773]` at `rho_tor = 0.251`; `bo` times the Boozer chart's own `[1/Bmax, 1/Bmin]` is `[0.9063, 1.0777]`.
- **PENTRC's own second estimator agrees with the fix.** `omega_d_rlar` is `wdhat = q T/(2 eps ro**2 chrg bo)`, which *is* dimensionally a frequency and reproduces to 8 digits (`591.1770263` computed, `5.91177020E+002` written). It sits at `0.78x` the canonical operator, while the GAR bounce average sat at `8.26x` it. The two are not the same quantity, so only the order of magnitude is meant — but the dimensionally correct estimator inside PENTRC lands where the reference does.

## Physical consequence on the ITER case

The superbanana resonance sits at `x = -omega_E/omega_D`. With `omega_E ~ -6.4e3 rad/s`, the corrected `omega_D ~ 2.3e2` puts it at `x ~ 28`, out in the Maxwellian tail, where an inflated `omega_D` had put it at `x ~ 4.3`.

Same deck, byte-identical `pentrc.in`, only the binary differing, over `0.2 <= rho_tor <= 0.8`:

| channel | before | after |
|---|---:|---:|
| TGAR trapped | `-11.762 N m` | `-0.493 N m` |
| PGAR passing | `-0.544 N m` | `-0.917 N m` |

The trapped channel drops by `24x` and the balance becomes passing-dominated, which is what the drift-kinetic codes we compare against report for this case.

## Gates

- `pentrc_tgar_n3.out` and `pentrc_pgar_n3.out` **bit-identical at 1 and 16 threads**, so #280's race fix is undisturbed.
- No sign is changed anywhere. After the magnitude is corrected, `omega_D` still opposes the reference operator evaluated on a right-handed chart; that is a separate open question about GPEC's runtime helicity and is deliberately left alone here.

## Adjacent, reported and not changed

The reduced-large-aspect-ratio branch has its own dimensional oddities — `wbbar` there carries `sqrt(bo)`, and unlike the GAR branch `bhat` is not divided by `ro` (`torque.F90:457-461`). Our deck exercises TGAR/PGAR, so I have not touched RLAR; flagging it in case it is of interest.

## Charge-verified TC24 production revalidation (2026-07-26)

The corrected single-D campaign was rerun from Xingting's archive (SHA-256 `655ffbf16e35f6218d1b40f58b2e2c4c16fbbcd8b1fce58c3adad515a7f17585`) at this exact head, `2e031ae675205ec9d69bb0298855155737f72579`. It uses `ni=ne=supplied density`, physical `Ti`/`Te`, `mi=2`, `zi=1`, and the paired `idcon_equil.out` `psi_pol -> s_tor` map.

Over the exact `0.2 <= rho_tor <= 0.8` window, the executable-native endpoints are:

| deck | trapped [N m] | passing [N m] | total [N m] |
|---|---:|---:|---:|
| L0 | +0.0508510 | -0.00330114 | +0.0475499 |
| L5 | -0.469088 | -0.948124 | -1.417212 |

The channel sum reconstructs the native cumulative torque. These numbers supersede the earlier old-profile physical-consequence table as TC24 comparison evidence. No sign was transformed: the audit retains native signs, while publication remains magnitude-only until the exact runtime helicity and manufactured nonzero complex-mode torque/power gate close.