### PR TITLE
PENTRC: preserve periodicity in parallel-velocity spline

### DIFF
--- a/pentrc/torque.F90
+++ b/pentrc/torque.F90
@@ -460,7 +460,7 @@ module torque
                     fbnce%fs(ilmda-1,3) = wbbar*djdj
                     ! bounce locations recorded for optional output
                     vspl%fs(:,1) = 1.0-(lmda/bo)*tspl%fs(:,1)
-                    call spline_fit(vspl,"extrap")
+                    call spline_fit(vspl,"periodic")
                     call spline_roots(vspl,1,nbpts,bpts)
                     if(nbpts<1)then
                         print *, "!! WARNING: Found passing particle in bounce particle integrals"
@@ -597,7 +597,7 @@ module torque
 
                     ! determine bounce points
                     vspl%fs(:,1) = 1.0-(lmda/bo)*tspl%fs(:,1)
-                    call spline_fit(vspl,"extrap")
+                    call spline_fit(vspl,"periodic")
                     if(sigma==0)then ! find trapped particle bounce pts
                         call spline_roots(vspl, 1, nbpts, bpts)
                         if(nbpts < 1)then


### PR DESCRIPTION
## What changed

Fit both PENTRC parallel-velocity root splines with periodic rather than
extrapolating endpoint conditions.

## Root cause

The sampled quantity,

```fortran
1.0 - (lambda / B0) * B(theta)
```

is periodic on the closed normalized poloidal-angle interval.  The equilibrium
`B(theta)` spline immediately upstream is periodic, but the derived root spline
was fitted with nonperiodic extrapolation conditions.  In the TC24 `phiI010`
L5 case the resulting seam corrupted bounce roots, produced non-finite
`omega_b` and `omega_D`, and reached LSODE as `ISTATE=-5`.

## Validation

- Clean GNU Fortran build from `develop`:
  `make -C install -j16 FC=gfortran CC=gcc OPENBLASHOME=/usr NETCDFHOME=/usr pentrc`
- Exact previously failing TC24 `phiI010` L5 input now terminates normally
  without an LSODE or non-finite-frequency failure.
- The repaired single-thread and 16-thread results are bit-for-bit identical
  for `pentrc_tgar_ell_n3.out`, `pentrc_pgar_ell_n3.out`,
  `pentrc_tgar_n3.out`, `pentrc_pgar_n3.out`, and `pentrc_output_n3.nc`.
- The same executable completed the `phiI000` and `phiI010` L0/L5 production
  matrix.

This changes only the spline boundary condition.  It does not change a
frequency, torque, helicity, or profile sign.
