### PR TITLE
CI: check dependency graph on fork PR heads

### DIFF
--- a/.github/workflows/make_test.yml
+++ b/.github/workflows/make_test.yml
@@ -18,7 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'


### PR DESCRIPTION
The `deps` job currently checks out `github.head_ref` from the base repository. On every fork PR that branch is absent, so the job fails before generating the dependency graph even when all compiler jobs pass.

Check out the event's actual head repository and immutable SHA. `workflow_dispatch` retains the current-repository/current-SHA fallback. The existing push block already treats inability to push a regenerated file to a fork as a warning, as documented in the workflow comment.

This is intentionally separate from #284, which changes only two PENTRC spline boundary conditions and otherwise passes all GNU/Intel build jobs.
