### PR TITLE
PENTRC: fix bspl column index in the vpar<=0 fill path

### DIFF
--- a/pentrc/torque.F90
+++ b/pentrc/torque.F90
@@ -690,7 +690,7 @@ module torque
                                 cycle
                             else
                                 bspl%fs(i-1:,1) = bspl%fs(i-2,1)
-                                bspl%fs(i-1:,2) = bspl%fs(i-2,1)
+                                bspl%fs(i-1:,2) = bspl%fs(i-2,2)
                                 jvtheta(i:) = jvtheta(i-1)
                                 exit
                             endif


### PR DESCRIPTION
Fixes #286. Found while reviewing #281, which corrects the normalization of the same integral.

## What this changes

One character in the GAR bounce-average `vpar<=0` handling:

```diff
                                 bspl%fs(i-1:,1) = bspl%fs(i-2,1)
-                                bspl%fs(i-1:,2) = bspl%fs(i-2,1)
+                                bspl%fs(i-1:,2) = bspl%fs(i-2,2)
                                 jvtheta(i:) = jvtheta(i-1)
```

## Why

`bspl%fs(:,1)` is the bounce-time integrand (`I1` -> `omega_b`) and `bspl%fs(:,2)` is the radial-derivative integrand (`I2` -> `omega_D`). When a `vpar` zero crossing is encountered past the well midpoint — the warning path near the trapped/passing boundary — the old code filled the remainder of the `I2` integrand with `I1` values. The intent (hold the last valid value per column) is clear from the matching column-1 line and from the analogous pre-bounce fill later in the loop, which uses matched columns.

## Scope

Affects the GAR-family methods (`fgar`/`tgar`/`pgar` and the `*mm` matrix methods) only for pitches that hit the `vpar<=0` warning path with `i >= ntheta/2`; results away from the trapped/passing boundary are unchanged. Present verbatim since the PENT->PENTRC rewrite import (`da0e6067`, June 2015); PENT itself did not have this fill path.

Compiles cleanly (gfortran). Independent of #281 (different lines; both apply cleanly in either order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rewp8poxoQyorK48SwxEUv