### PR TITLE
PENTRC: restore pitch-consistent clar normalizations (omega_b /sqrt(bo), omega_D /bo)

### DIFF
--- a/pentrc/torque.F90
+++ b/pentrc/torque.F90
@@ -443,10 +443,16 @@ module torque
                         kappa = sqrt((1 - lmda*(1- epsr))/(2*epsr*lmda))
                     endif
                     lnq = 1.0*l
-                    ! cylindrical bounce and precessions
-                    wbbar = pi*SQRT(2*epsr*lmda*bo)/(4*q*ro*ellipk(kappa**2))
+                    ! cylindrical bounce and precessions. These forms come from
+                    ! PENT, where the pitch variable was dimensional (1/Tesla,
+                    ! vpar = 1 - lmda*b). Here lmda is the dimensionless
+                    ! Lambda = lmda_pent*bo, so the PENT expressions map to
+                    ! sqrt(2*epsr*lmda) (no bo) and a bo in the wdbar
+                    ! denominator; keeping the PENT text verbatim inflated
+                    ! omega_b by sqrt(bo) and omega_D by bo.
+                    wbbar = pi*SQRT(2*epsr*lmda)/(4*q*ro*ellipk(kappa**2))
                     wdbar = (2*q*lmda*(ellipe(kappa**2)/ellipk(kappa**2)-0.5)&
-                        /(ro**2*epsr))*wdfac
+                        /(bo*ro**2*epsr))*wdfac
                     bhat = SQRT(2*kin_f(s+2)/mass)
                     dhat = (kin_f(s+2)/chrg)
                     ! perturbed action Eq. (12) [Park, Phys. Rev. Lett. 2009] divided by 2pi for DCON phi normalization


### PR DESCRIPTION
Fixes #287. Companion to #281, same root cause found via the git archaeology done for that review.

## What this changes

Two factors in the `clar` bounce-average branch of `pentrc/torque.F90`:

```diff
-                    wbbar = pi*SQRT(2*epsr*lmda*bo)/(4*q*ro*ellipk(kappa**2))
+                    wbbar = pi*SQRT(2*epsr*lmda)/(4*q*ro*ellipk(kappa**2))
                     wdbar = (2*q*lmda*(ellipe(kappa**2)/ellipk(kappa**2)-0.5)&
-                        /(ro**2*epsr))*wdfac
+                        /(bo*ro**2*epsr))*wdfac
```

plus a comment recording why.

## Why

In PENT (`pent/profile.f`, 2013-2015) the pitch variable was dimensional (`vpar = 1 - lmda*b`, `lmda` in 1/Tesla) and these formulas were consistent with it: `lmda*bo` under the square root was dimensionless, and `wdbar*dhat = (T/chrg)*2*q*lmda*G/(ro**2*eps)` was a frequency because `lmda` carried the `1/bo`.

The PENT->PENTRC rewrite (`da0e6067`, June 2015) nondimensionalized the pitch (`Lambda = lmda_pent*bo`, `vpar = 1 - (lmda/bo)*b`) but kept the `clar` text verbatim. Substituting `lmda_pent = Lambda/bo`:

- `kappa` maps exactly (PENT's `kk = (1/bo - lmda(1-eps))/(2*eps*lmda)` is identical to PENTRC's `kk = (1 - lmda(1-eps))/(2*eps*lmda)`), so trapped-space geometry needs no change;
- `wbbar` retained a spurious `sqrt(bo)` and `wdbar` a spurious `bo`.

So `clar` has reported `omega_b` inflated by `sqrt(bo)` (~1.4-2.3x) and `omega_D` inflated by `bo` (~2-5.3x) since 2015. This PR restores exactly the forms PENT evaluated. This is the same failure mode as the GAR `ro` in #281 — normalization conventions changed under formulas that were not updated — and, like #281, it multiplies by positive numbers and changes no sign.

## Scope

- Affects only the `clar` method (`fbnce` channels 1-3: `omega_b`, `omega_D`, and the `wbbar`-scaled action).
- The `rlar` method's flux-surface estimators (`wbhat`/`wdhat`, built from `wtran`/`wgyro`) are dimensionally sound and untouched.
- GAR methods are handled by #281; independent lines, applies cleanly in either order.

## Verification status

Analytic + historical (the PENT mapping above); compiles cleanly with gfortran. It has **not** been benchmarked against an independent reference operator the way #281 was — a re-run of #281's slope-vs-reference measurement on the `clar` branch should read `sqrt(bo)` and `bo` before this patch and ~1 after, and would be a welcome check before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rewp8poxoQyorK48SwxEUv