### PR TITLE
PENTRC: document atol_x/rtol_x controls and fix precision suffix (cleanup for #280)

### DIFF
--- a/docs/examples/DIIID_ideal_example/pentrc.in
+++ b/docs/examples/DIIID_ideal_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-6                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-6                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-4                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/DIIID_kinetic_example/pentrc.in
+++ b/docs/examples/DIIID_kinetic_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-5                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-5                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-3                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/DIIID_resistive_example/pentrc.in
+++ b/docs/examples/DIIID_resistive_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-6                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-6                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-4                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/a10_ideal_example/pentrc.in
+++ b/docs/examples/a10_ideal_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-5                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-5                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-9                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/a10_kinetic_example/pentrc.in
+++ b/docs/examples/a10_kinetic_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-5                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-5                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-9                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/a5_tearing_example/pentrc.in
+++ b/docs/examples/a5_tearing_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-5                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-5                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-9                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/regression_solovev_ideal_example/pentrc.in
+++ b/docs/examples/regression_solovev_ideal_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-5                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-5                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-9                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/regression_solovev_kinetic_example/pentrc.in
+++ b/docs/examples/regression_solovev_kinetic_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-5                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-5                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-9                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/regression_solovev_resistive_example/pentrc.in
+++ b/docs/examples/regression_solovev_resistive_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-5                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-5                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-9                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/run_ideal_example/pentrc.in
+++ b/docs/examples/run_ideal_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-6                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-6                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-9                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/run_kinetic_example/pentrc.in
+++ b/docs/examples/run_kinetic_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-5                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-5                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-4                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/solovev_ideal_example/pentrc.in
+++ b/docs/examples/solovev_ideal_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-6                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-6                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-9                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/solovev_kinetic_example/pentrc.in
+++ b/docs/examples/solovev_kinetic_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-5                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-5                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-9                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/docs/examples/solovev_resistive_example/pentrc.in
+++ b/docs/examples/solovev_resistive_example/pentrc.in
@@ -25,8 +25,8 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-6                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-6                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
     atol_psi = 1e-9                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-5                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/input/pentrc.in
+++ b/input/pentrc.in
@@ -25,8 +25,10 @@
 
     force_xialpha = .false.             ! Calculates tangential displacement from radial displacement and toroidal force balance (overwrites peq_file values)
 
-    atol_xlmda = 1e-9                   ! Absolute tolerance in energy and pitch integration
-    rtol_xlmda = 1e-5                   ! Relative tolerance in energy and pitch integration
+    atol_xlmda = 1e-9                   ! Absolute tolerance in pitch integration (energy tolerance derived from this unless atol_x is set)
+    rtol_xlmda = 1e-5                   ! Relative tolerance in pitch integration (energy tolerance derived from this unless rtol_x is set)
+    atol_x = -1                         ! Absolute tolerance in energy integration. Negative (default) derives 1e-2*atol_xlmda so the nested quadrature converges
+    rtol_x = -1                         ! Relative tolerance in energy integration. Negative (default) derives 1e-2*rtol_xlmda so the nested quadrature converges
     atol_psi = 1e-4                     ! Absolute tolerance in psi_n integration
     rtol_psi = 1e-4                     ! Relative tolerance in psi_n integration
     ntheta = 128                        ! Poloidal angle grid for bounce integration

--- a/pentrc/pentrc_interface.f90
+++ b/pentrc/pentrc_interface.f90
@@ -113,7 +113,7 @@ module pentrc_interface
 
     !> How much tighter the energy integration is than the pitch integration
     !> when atol_x/rtol_x are left at their derive-me default.
-    real(r8), parameter :: nested_tolerance_margin = 1e-2
+    real(r8), parameter :: nested_tolerance_margin = 1e-2_r8
 
     real(r8) ::    &
         atol_xlmda=1e-6, &


### PR DESCRIPTION
Non-blocking cleanup items from the #280 review, as a follow-up so #280 could merge as-authored:

- Adds the new `atol_x`/`rtol_x` energy-integration controls to `input/pentrc.in` with comments explaining the derive-from-pitch default (`1e-2` margin).
- Corrects the `atol_xlmda`/`rtol_xlmda` comments in the master template and all 14 example decks: they are pitch-only tolerances now, with the energy tolerances derived unless overridden (#280 made the old "energy and pitch" wording untrue).
- `nested_tolerance_margin = 1e-2` → `1e-2_r8` per the project's precision conventions.

No behavior change: the `_r8` suffix shifts the margin only at the single-vs-double literal conversion level (~5e-10 relative), and the template edits are comments plus explicit defaults.

**Draft until #280 (and #281) merge** — this branch is based on #280's head so the diff currently includes its commits; it collapses to the 16-file cleanup once #280 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rewp8poxoQyorK48SwxEUv